### PR TITLE
LSP-1807-Use-pathlib-instead-of-ospath

### DIFF
--- a/gen_epix/casedb/app.py
+++ b/gen_epix/casedb/app.py
@@ -1,10 +1,9 @@
-from pkg_resources import get_distribution
-
 from gen_epix.casedb.app_setup import create_fast_api
 from gen_epix.casedb.domain import enum
 from gen_epix.casedb.domain.enum import ServiceType
 from gen_epix.casedb.env import AppEnv
 from util.cfg import AppCfg
+from util.version import get_project_version
 
 APP_NAME = "CASEDB"
 
@@ -13,7 +12,7 @@ SCHEMA_KWARGS = {
     "title": "Gen-EpiX",
     "summary": "Genomic Epidemiology platform for disease X",
     "description": "Gen-EpiX is platform for visualizing and analyzing genomic epidemiology data. It has fine-grained access controls for collaboration between multiple organizations.",
-    "version": get_distribution("gen-epix").version,
+    "version": get_project_version(),
     "contact": {
         "name": "RIVM CIb IDS bioinformatics group",
         "url": "https://github.com/RIVM-bioinformatics/gen-epix-api",

--- a/gen_epix/casedb/domain/command/role.py
+++ b/gen_epix/casedb/domain/command/role.py
@@ -113,6 +113,7 @@ class RoleGenerator:
             (command.CaseTypeCrudCommand, PermissionTypeSet.R),
             (command.CaseTypeSetCategoryCrudCommand, PermissionTypeSet.R),
             (command.CaseTypeSetCrudCommand, PermissionTypeSet.R),
+            (command.CaseTypeColSetMemberCrudCommand, PermissionTypeSet.R),
             (command.CaseTypeSetMemberCrudCommand, PermissionTypeSet.R),
             (
                 command.CaseDataCollectionLinkCrudCommand,

--- a/gen_epix/common/api/exc.py
+++ b/gen_epix/common/api/exc.py
@@ -5,6 +5,13 @@ from typing import Any, Callable, Hashable
 
 from gen_epix.fastapp import App, LogLevel, model
 from gen_epix.fastapp.api import exc as api_exc
+from gen_epix.fastapp.exc import (
+    AuthException,
+    DomainException,
+    DuplicateIdsError,
+    IdsError,
+    ServiceException,
+)
 
 http_exception_fmap = {
     400: api_exc.BadRequest400HTTPException,
@@ -69,8 +76,8 @@ def generate_handle_exception_function(
             log_message_id, None, user_id=user.id if user else None, exception=exception  # type: ignore[arg-type]
         )
         # Raise HTTP exception
-        if isinstance(exception, exc.DomainException):
-            if isinstance(exception, exc.IdsError):
+        if isinstance(exception, DomainException):
+            if isinstance(exception, IdsError):
                 invalid_ids = []
                 if request_ids and exception.ids:
                     # Compare ids received in request with those reported
@@ -89,7 +96,7 @@ def generate_handle_exception_function(
                     invalid_ids = [x for x in request_ids if x in exception.ids]
                 if invalid_ids:
                     # (Part of the) issue is with id(s). Provide detail on that.
-                    if isinstance(exception, exc.DuplicateIdsError):
+                    if isinstance(exception, DuplicateIdsError):
                         invalid_ids_str = ", ".join(
                             [f'"{x}"' for x in set(invalid_ids)]
                         )
@@ -105,13 +112,13 @@ def generate_handle_exception_function(
                 if logger:
                     logger.info(log_message)
                 raise http_exception_fmap[422]() from exception
-            elif isinstance(exception, exc.AuthException):
+            elif isinstance(exception, AuthException):
                 if logger:
                     logger.info(log_message)
                 raise http_exception_fmap[exception.get_http_status_code()](
                     detail="Access denied", **exception.get_http_other_props()
                 ) from exception
-            elif isinstance(exception, exc.ServiceException):
+            elif isinstance(exception, ServiceException):
                 if logger:
                     logger.error(log_message)
                 raise http_exception_fmap[exception.get_http_status_code()](

--- a/gen_epix/fastapp/repositories/sa/repository.py
+++ b/gen_epix/fastapp/repositories/sa/repository.py
@@ -1,7 +1,7 @@
-import os
 import re
 import uuid
 import warnings
+from pathlib import Path
 from typing import Any, Callable, Hashable, Iterable, Self, Sequence, Type
 
 import sqlalchemy as sa
@@ -973,13 +973,14 @@ class SARepository(BaseRepository):
             )
             if recreate_sqlite_file:
                 # Remove existing file
-                if os.path.isfile(sqlite_file):
-                    os.remove(sqlite_file)
+                if Path(sqlite_file).is_file():
+                    Path(sqlite_file).unlink()
+
                 # Create the file by creating a connection
                 engine = sa.create_engine("sqlite:///" + sqlite_file)
                 conn = engine.connect()
                 conn.close()
-            elif not os.path.isfile(sqlite_file):
+            elif not Path(sqlite_file).is_file():
                 raise ValueError("Unable to derive file from connection string")
 
             # Filter some warnings

--- a/gen_epix/omopdb/app.py
+++ b/gen_epix/omopdb/app.py
@@ -1,9 +1,8 @@
-from pkg_resources import get_distribution
-
 from gen_epix.omopdb.app_setup import create_fast_api
 from gen_epix.omopdb.domain import enum
 from gen_epix.omopdb.env import AppEnv
 from util.cfg import AppCfg
+from util.version import get_project_version
 
 APP_NAME = "OMOPDB"
 
@@ -12,7 +11,7 @@ SCHEMA_KWARGS = {
     "title": "BioBase master database",
     "description": "BioBase API",
     "summary": "Summary goes here",
-    "version": get_distribution("gen-epix").version,
+    "version": get_project_version(),
     "terms_of_service": "http://example.com/terms/",
     "contact": {
         "name": "RIVM CIb IDS bioinformatics group",

--- a/gen_epix/seqdb/app.py
+++ b/gen_epix/seqdb/app.py
@@ -1,9 +1,8 @@
-from pkg_resources import get_distribution
-
 from gen_epix.seqdb.app_setup import create_fast_api
 from gen_epix.seqdb.domain import enum
 from gen_epix.seqdb.env import AppEnv
 from util.cfg import AppCfg
+from util.version import get_project_version
 
 APP_NAME = "SEQDB"
 
@@ -12,7 +11,7 @@ SCHEMA_KWARGS = {
     "title": "Sequence database",
     "description": "Sequence database API",
     "summary": "Summary goes here",
-    "version": get_distribution("gen-epix").version,
+    "version": get_project_version(),
     "terms_of_service": "http://example.com/terms/",
     "contact": {
         "name": "RIVM CIb IDS bioinformatics group",

--- a/run.py
+++ b/run.py
@@ -665,12 +665,12 @@ class Run:
         df = pd.DataFrame.from_dict(
             {f"uuid{i}": [generate_ulid() for j in range(n_rows)] for i in range(100)}
         )
-        xls_file = os.path.join(
-            os.path.dirname(__file__), "test", "data", "output", "generated_uuids.xlsx"
+        xls_file = (
+            Path(__file__).parent / "test" / "data" / "output" / "generated_uuids.xlsx"
         )
         df.to_excel(xls_file, sheet_name="uuid", index=False)
         print(
-            f"Total of {n_rows} uuids times {df.shape[1]} columns generated and written to file {xls_file}"
+            f"Total of {n_rows} uuids times {df.shape[1]} columns generated and written to file {str(xls_file)}"
         )
 
     def other_general_run_linters(self) -> None:
@@ -742,11 +742,14 @@ class Run:
         from test.test_client.log_parser_v1 import V1LogParser
         from test.test_client.log_parser_v2 import V2LogParser
 
-        path = path or os.path.join("test", "data", "output", "log.debug.txt")
-        out_log_excel_file = os.path.join(os.path.dirname(path), "log.debug.xlsx")
-        out_user_journey_file = os.path.join(
-            os.path.dirname(path), "log.user_journey.pkl.gz"
-        )
+        if path:
+            path_obj = Path(path)
+        else:
+            path_obj = Path("test") / "data" / "output" / "log.debug.txt"
+        out_log_excel_file = str(path_obj.parent / "log.debug.xlsx")
+        out_user_journey_file = str(path_obj.parent / "log.user_journey.pkl.gz")
+        path = str(path_obj)
+
         log_parser: LogParser
         if not version or version == 2:
             log_parser = V2LogParser(path)
@@ -760,18 +763,18 @@ class Run:
         user_journey.to_pickle(out_user_journey_file)
 
     def other_seqdb_parse_ncbi_taxonomy(self) -> None:
-        dir = os.path.join(os.getcwd(), ".ete")
-        os.environ["HOME"] = dir
-        os.environ["XDG_DATA_HOME"] = os.path.join(dir, "data")
-        os.environ["XDG_CONFIG_HOME"] = os.path.join(dir, "config")
-        os.environ["XDG_CACHE_HOME"] = os.path.join(dir, "cache")
+        dir = Path.cwd() / ".ete"
+        os.environ["HOME"] = str(dir)
+        os.environ["XDG_DATA_HOME"] = str(dir / "data")
+        os.environ["XDG_CONFIG_HOME"] = str(dir / "config")
+        os.environ["XDG_CACHE_HOME"] = str(dir / "cache")
         from util.ncbi_taxonomy import parse_ncbi_taxonomy
 
         parse_ncbi_taxonomy()
 
     def other_seqdb_parse_alleles(self) -> None:
-        dir = os.path.join(os.getcwd(), ".ete")
-        os.environ["HOME"] = dir
+        dir = Path.cwd() / ".ete"
+        os.environ["HOME"] = str(dir)
         from util.wgmlst import parse_alleles
 
         parse_alleles()

--- a/test/casedb/performance/repository/test_main_repository.py
+++ b/test/casedb/performance/repository/test_main_repository.py
@@ -1,9 +1,9 @@
 import cProfile
 import logging
-import os
 import pstats
 import sys
 import test.test_client.util as test_util
+from pathlib import Path
 from test.test_client.enum import TestType as EnumTestType  # to avoid PyTest warning
 from test.test_client.service_test_client import ServiceTestClient
 from test.test_client.util import parse_stats
@@ -58,9 +58,5 @@ class TestRead:
             repository_type=enum.RepositoryType.DICT,
         ).test_dir
         df = pd.DataFrame.from_records(PERFORMANCE_DF)
-        df.to_csv(
-            os.path.join(test_dir, cls.__name__) + ".performance.csv", index=False
-        )
-        df.to_excel(
-            os.path.join(test_dir, cls.__name__) + ".performance.xlsx", index=False
-        )
+        df.to_csv(Path(test_dir) / f"{cls.__name__}.performance.csv", index=False)
+        df.to_excel(Path(test_dir) / f"{cls.__name__}.performance.xlsx", index=False)

--- a/test/casedb/performance/startup/test_startup.py
+++ b/test/casedb/performance/startup/test_startup.py
@@ -1,7 +1,7 @@
 import cProfile
 import logging
-import os
 import pstats
+from pathlib import Path
 from test.test_client.util import parse_stats
 
 import pandas as pd
@@ -72,15 +72,11 @@ class TestStartup:
             test_type=EnumTestType.CASEDB_PERFORMANCE_STARTUP,
             repository_type=RepositoryType.DICT,
         ).test_dir
-        with open(os.path.join(test_dir, cls.__name__) + ".performance.html", "w") as f:
+        with open(Path(test_dir) / f"{cls.__name__}.performance.html", "w") as f:
             f.write("".join(PERFORMANCE_HTML))
         df = pd.DataFrame.from_records(PERFORMANCE_DF)
-        df.to_csv(
-            os.path.join(test_dir, cls.__name__) + ".performance.csv", index=False
-        )
-        df.to_excel(
-            os.path.join(test_dir, cls.__name__) + ".performance.xlsx", index=False
-        )
+        df.to_csv(Path(test_dir) / f"{cls.__name__}.performance.csv", index=False)
+        df.to_excel(Path(test_dir) / f"{cls.__name__}.performance.xlsx", index=False)
 
     # @classmethod
     # def tearDownClass(cls):
@@ -90,8 +86,8 @@ class TestStartup:
     #     ).test_dir
     #     df = pd.DataFrame.from_records(PERFORMANCE_DF)
     #     df.to_csv(
-    #         os.path.join(test_dir, cls.__name__) + ".performance.csv", index=False
+    #         Path(test_dir) / f"{cls.__name__}.performance.csv", index=False
     #     )
     #     df.to_excel(
-    #         os.path.join(test_dir, cls.__name__) + ".performance.xlsx", index=False
+    #         Path(test_dir) / f"{cls.__name__}.performance.xlsx", index=False
     #     )

--- a/test/casedb/performance/user_journey/test_user_journey.py
+++ b/test/casedb/performance/user_journey/test_user_journey.py
@@ -1,11 +1,11 @@
 import cProfile
 import logging
-import os
 import pickle
 import pstats
 import re
 import sys
 import test.test_client.util as test_util
+from pathlib import Path
 from test.test_client.enum import TestType as EnumTestType  # to avoid pytest warning
 from test.test_client.log_parser_v1 import V1LogParser
 from test.test_client.log_parser_v2 import V2LogParser
@@ -23,9 +23,7 @@ PERFORMANCE_DF: list = []
 PERFORMANCE_HTML: dict = {}
 V1_USER_JOURNEY_FILE_PREFIX = "v1.user_journey"
 V2_USER_JOURNEY_FILE_PREFIX = "v2.user_journey"
-USER_JOURNEY_DIR = os.path.join(
-    os.path.dirname(test_util.__file__), "data", "user_journey"
-)
+USER_JOURNEY_DIR = Path(test_util.__file__).parent / "data" / "user_journey"
 
 
 class TestRead:
@@ -35,17 +33,17 @@ class TestRead:
         # TODO: add functionality to get only user journeys for a particular scenario (read, update, etc.)
         if TestRead.USER_JOURNEYS is None:
             TestRead.USER_JOURNEYS = []
-            for file in os.listdir(USER_JOURNEY_DIR):
+            for file in USER_JOURNEY_DIR.iterdir()::
                 if not re.match(r".*\.log\.txt(\.gz)?$", file, flags=re.IGNORECASE):
                     continue
-                src_file = os.path.join(USER_JOURNEY_DIR, file)
-                pkl_file = os.path.join(src_file + ".pkl.gz")
-                if os.path.isfile(pkl_file):
-                    if os.path.getmtime(pkl_file) > os.path.getmtime(src_file):
+                src_file = file
+                pkl_file = Path(str(pkl_file) + ".pkl.gz")
+                if pkl_file.is_file():
+                    if pkl_file.stat().st_mtime > src_file.stat().st_mtime:
                         TestRead.USER_JOURNEYS.append(pickle.load(open(pkl_file, "rb")))
                         continue
                     else:
-                        os.remove(pkl_file)
+                        pkl_file.unlink()
                 if file.startswith(V1_USER_JOURNEY_FILE_PREFIX):
                     name = re.sub(
                         V1_USER_JOURNEY_FILE_PREFIX + r".*\.(\w+)\.log\.txt(\.gz)?$",
@@ -149,13 +147,13 @@ class TestRead:
         ).test_dir
         df = pd.DataFrame.from_records(PERFORMANCE_DF)
         df.to_csv(
-            os.path.join(test_dir, cls.__name__) + ".performance.csv", index=False
+            Path(test_dir) / f"{cls.__name__}.performance.csv", index=False
         )
         df.to_excel(
-            os.path.join(test_dir, cls.__name__) + ".performance.xlsx", index=False
+            Path(test_dir) / f"{cls.__name__}.performance.xlsx", index=False
         )
         for key, html_str in PERFORMANCE_HTML.items():
             with open(
-                os.path.join(test_dir, cls.__name__) + f".performance.{key}.html", "w"
+                Path(test_dir) / f"{cls.__name__}.performance.{key}.html", "w"
             ) as f:
                 f.write("".join(html_str))

--- a/test/fastapp/performance/test_service_repository.py
+++ b/test/fastapp/performance/test_service_repository.py
@@ -1,5 +1,4 @@
 import cProfile
-import os
 import pstats
 import uuid
 from test.fastapp.command import Model2_2CrudCommand
@@ -106,14 +105,10 @@ class TestRepository:
             return
         test_dir = env.test_dir
         df = pd.DataFrame.from_records(PERFORMANCE_DF)
-        df.to_csv(
-            os.path.join(test_dir, cls.__name__) + ".performance.csv", index=False
-        )
-        df.to_excel(
-            os.path.join(test_dir, cls.__name__) + ".performance.xlsx", index=False
-        )
+        df.to_csv(Path(test_dir) / f"{cls.__name__}.performance.csv", index=False)
+        df.to_excel(Path(test_dir) / f"{cls.__name__}.performance.xlsx", index=False)
         for key, html_str in PERFORMANCE_HTML.items():
             with open(
-                os.path.join(test_dir, cls.__name__) + f".performance.{key}.html", "w"
+                Path(test_dir) / f"{cls.__name__}.performance.{key}.html", "w"
             ) as f:
                 f.write("".join(html_str))

--- a/test/fastapp/service_test_client.py
+++ b/test/fastapp/service_test_client.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from test.fastapp.command import (
     Model1_1CrudCommand,
     Model1_2CrudCommand,
@@ -37,8 +37,8 @@ class ServiceTestClient:
     def __init__(self, repository_class: Type[BaseRepository], **kwargs: dict) -> None:
         self.test_type = kwargs.get("test_type", repository_class.__name__)
         self.test_name = kwargs.get("test_name", get_test_name(self.test_type))
-        self.test_dir = os.path.join(get_test_root_output_dir(), self.test_name)
-        os.makedirs(self.test_dir, exist_ok=True)
+        self.test_dir = Path(get_test_root_output_dir()) / self.test_name
+        self.test_dir.mkdir(parents=True, exist_ok=True)
         self.repository_type = kwargs.get("repository_type", repository_class.__name__)
         self.user_manager = kwargs.pop("user_manager", UserManager())
         self.app = App(user_manager=self.user_manager, **kwargs)
@@ -132,8 +132,8 @@ class ServiceTestClient:
         if issubclass(repository_class, DictRepository):
             repository = DictRepository(entities, {}, missing_data="ignore")
         elif issubclass(repository_class, SARepository):
-            sqlite_file = os.path.join(self.test_dir, f"{name}.sqlite")
-            connection_string = f"sqlite:///{sqlite_file}"
+            sqlite_file = Path(self.test_dir) / f"{name}.sqlite"
+            connection_string = f"sqlite:///{str(sqlite_file)}"
             repository = repository_class.create_sa_repository(
                 entities,
                 connection_string,
@@ -148,9 +148,9 @@ class ServiceTestClient:
             #     raise ValueError("Multiple schemas are not supported")
             # schema_name = schema_names.pop()
 
-            # sqlite_file = os.path.join(self.test_dir, f"{name}.sqlite")
-            # if os.path.exists(sqlite_file):
-            #     os.remove(sqlite_file)
+            # sqlite_file = Path(self.test_dir) / f"{name}.sqlite"
+            # if sqlite_file.is_file():
+            #     sqlite_file.unlink()
 
             # @sa.event.listens_for(sa.Engine, "connect")
             # def set_sqlite_pragma(dbapi_connection, _) -> None:

--- a/test/test_client/log_parser_v1.py
+++ b/test/test_client/log_parser_v1.py
@@ -1,6 +1,5 @@
 import gzip
 import json
-import os
 from datetime import datetime
 from enum import Enum
 from test.test_client.log_parser import AzureColumn, LogCode, LogParser, LogType
@@ -110,7 +109,7 @@ class V1LogParser(LogParser):
         self.log_error_lines = None
         # Verify existence of log files
         for log_file in self.log_files:
-            if not os.path.isfile(log_file):
+            if not Path(log_file).is_file():
                 raise FileNotFoundError(f"Log file not found: {log_file}")
 
     def parse(self, **kwargs: dict) -> tuple[list[dict], list[str]]:
@@ -140,7 +139,7 @@ class V1LogParser(LogParser):
         records = []
         error_lines = []
         for log_file in self.log_files:
-            _, file_extension = os.path.splitext(log_file)
+            file_extension = Path(log_file).suffix
             if self.log_type == LogType.DIRECT:
                 with (
                     gzip.open(log_file, "rt")

--- a/test/test_client/log_parser_v2.py
+++ b/test/test_client/log_parser_v2.py
@@ -1,8 +1,8 @@
 import gzip
 import json
-import os
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from test.test_client.log_parser import AzureColumn, LogCode, LogParser, LogType
 from test.test_client.user_journey_v2 import UserJourneyColumn, V2UserJourney
 from typing import Callable, Iterable
@@ -122,7 +122,7 @@ class V2LogParser(LogParser):
         self.log_error_lines = None
         # Verify existence of log files
         for log_file in self.log_files:
-            if not os.path.isfile(log_file):
+            if not Path(log_file).is_file():
                 raise FileNotFoundError(f"Log file not found: {log_file}")
 
     def parse(self, **kwargs: dict) -> tuple[list[dict], list[str]]:
@@ -148,7 +148,7 @@ class V2LogParser(LogParser):
         records = []
         error_lines = []
         for log_file in self.log_files:
-            _, file_extension = os.path.splitext(log_file)
+            file_extension = Path(log_file).suffix
             if self.log_type == LogType.DIRECT:
                 with (
                     gzip.open(log_file, "rb")

--- a/test/test_client/service_test_client.py
+++ b/test/test_client/service_test_client.py
@@ -1,9 +1,9 @@
 import datetime
 import logging
-import os
 import re
 import shutil
 from enum import Enum
+from pathlib import Path
 from test.test_client.endpoint_test_client import EndpointTestClient, EndpointVersion
 from test.test_client.enum import RepositoryType, TestType
 from test.test_client.util import get_test_name, get_test_output_dir, set_log_level
@@ -358,9 +358,9 @@ class ServiceTestClient:
                         curr_cfg["file"],
                         flags=re.IGNORECASE,
                     )
-                    if not os.path.isfile(source_file):
+                    if not Path(source_file).is_file():
                         continue
-                    target_file = os.path.join(test_dir, os.path.basename(source_file))
+                    target_file = Path(test_dir) / Path(source_file).name
                     curr_cfg["file"] = target_file
                     shutil.copyfile(source_file, target_file)
                 case RepositoryType.SA_SQL:

--- a/test/test_client/util.py
+++ b/test/test_client/util.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
-import os
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -18,14 +18,14 @@ def get_test_name(test_type: Enum | str) -> str:
 
 
 def get_test_root_output_dir() -> str:
-    dir = os.path.join(os.path.dirname(__file__), "data", "output")
-    os.makedirs(dir, exist_ok=True)
+    dir = Path(__file__).parent / "data" / "output"
+    dir.mkdir(parents=True, exist_ok=True)
     return dir
 
 
 def get_test_output_dir(test_name: str) -> str:
-    output_dir = os.path.join(get_test_root_output_dir(), test_name)
-    os.makedirs(output_dir, exist_ok=True)
+    output_dir = Path(get_test_root_output_dir()) / test_name
+    output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir
 
 

--- a/util/cfg.py
+++ b/util/cfg.py
@@ -6,6 +6,7 @@ import os
 import uuid
 from enum import Enum
 from locale import getpreferredencoding
+from pathlib import Path
 from typing import Any, Type
 from urllib.parse import quote_plus
 
@@ -222,12 +223,12 @@ class AppCfg(BaseAppCfg):
         settings_dir = os.environ[
             AppCfg._prefix_envvar(envvar_prefix, settings_dir_envvar)
         ]
-        if not os.path.isdir(settings_dir):
+        if not Path(settings_dir).is_dir():
             msg = f"Settings directory does not exist: {settings_dir}"
             self._setup_logger.error(App.create_static_log_message("e0d6f1d2", msg))
             raise FileNotFoundError(msg)
-        settings_full_files = [os.path.join(settings_dir, x) for x in settings_files]
-        invalid_files = [x for x in settings_full_files if not os.path.isfile(x)]
+        settings_full_files = [Path(settings_dir) / x for x in settings_files]
+        invalid_files = [x for x in settings_full_files if not x.is_file()]
         if invalid_files:
             invalid_files_str = ", ".join(invalid_files)
             msg = f"Some settings files do not exist: {invalid_files_str}"
@@ -284,7 +285,7 @@ class AppCfg(BaseAppCfg):
             logger.error(App.create_static_log_message("e2547edf", msg))
             raise FileNotFoundError(msg)
         idps_config_file = cfg.get(idps_config_file_envvar)
-        if not os.path.isfile(idps_config_file):
+        if not Path(idps_config_file).is_file():
             msg = f"Authentication settings file does not exist: {idps_config_file}"
             logger.error(App.create_static_log_message("dc779cad", msg))
             raise FileNotFoundError(msg)
@@ -339,7 +340,7 @@ class AppCfg(BaseAppCfg):
         else:
             secrets_dir = cfg.get(secrets_dir_envvar)
             if secrets_dir:
-                if not os.path.isdir(secrets_dir):
+                if not Path(secrets_dir).is_dir():
                     msg = f"Secrets directory does not exist: {secrets_dir}"
                     logger.error(App.create_static_log_message("d7190d85", msg))
                     raise FileNotFoundError(msg)

--- a/util/data.py
+++ b/util/data.py
@@ -1,17 +1,17 @@
 import gzip
-import os
 import pickle
 import sys
+from pathlib import Path
 
 import pandas as pd
 
 from util.util import generate_ulid
 
-sys.path.append(os.path.join(os.getcwd()))
+sys.path.append(str(Path.cwd()))
 
-db_file_name = os.path.join(os.getcwd(), "data/CASEDB - Reference data.pkl.gz")
-out_excel_file_name = os.path.join(
-    os.getcwd(), "data/CASEDB - Reference data.extra_case_type_set_members.xlsx"
+db_file_name = Path.cwd() / "data/CASEDB - Reference data.pkl.gz"
+out_excel_file_name = (
+    Path.cwd() / "data/CASEDB - Reference data.extra_case_type_set_members.xlsx"
 )
 
 

--- a/util/ncbi_taxonomy.py
+++ b/util/ncbi_taxonomy.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sqlite3
+from pathlib import Path
 from uuid import UUID
 
 import pandas as pd
@@ -147,7 +148,7 @@ def update_ncbi_taxonomy(update_database: bool = False) -> None:
 
 def read_ncbi_taxonomy() -> pd.DataFrame:
     # Retrieve data from sqlite database with NCBI taxonomy created by ete package
-    file = os.path.join(os.environ["XDG_DATA_HOME"], "ete", "taxa.sqlite")
+    file = Path(os.environ["XDG_DATA_HOME"]) / "ete" / "taxa.sqlite"
     conn = sqlite3.connect(file)
     ncbi_df = pd.read_sql_query("SELECT * FROM species", conn)
     conn.close()
@@ -200,15 +201,16 @@ def get_ncbi_taxon_subset(ncbi_df: pd.DataFrame) -> None:
     )
     ncbi_df.drop(ncbi_df.index[ncbi_df["is_unclassified_taxon"]], inplace=True)
     # # TODO: Temporary write out to facilitate debugging
-    # ncbi_df.to_pickle(os.path.join(os.environ["XDG_DATA_HOME"], "ncbi_taxonomy.pkl"))
+    # ncbi_df.to_pickle(Path(os.environ["XDG_DATA_HOME"]) / "ncbi_taxonomy.pkl")
+
     # ncbi_df.to_excel(
-    #     os.path.join(os.environ["XDG_DATA_HOME"], "ncbi_taxonomy.xlsx"),
+    #     Path(os.environ["XDG_DATA_HOME"]) / "ncbi_taxonomy.xlsx",
     #     sheet_name="ncbi_taxonomy",
     # )
 
 
 def retrieve_seqdb_taxon(file: str) -> pd.DataFrame:
-    if not os.path.exists(file):
+    if not Path(file).is_file():
         seqdb_df = pd.DataFrame.from_dict(
             {
                 "id": pd.Series([], dtype=object),
@@ -353,17 +355,15 @@ def get_seqdb_taxon_changes(
 
 def parse_ncbi_taxonomy(update_ncbi_database: bool = False) -> None:
     # Create some config data
-    seqdb_taxon_file = os.path.join(
-        os.getcwd(), "seqdb", "data", "extract", "seqdb.src.seq.taxon.tsv"
+    seqdb_taxon_file = (
+        Path.cwd() / "seqdb" / "data" / "extract" / "seqdb.src.seq.taxon.tsv"
     )
     out_files = {
-        x: os.path.join(
-            os.getcwd(),
-            "seqdb",
-            "data",
-            "extract",
-            f"seqdb.src.seq.taxon.{x.lower()}.tsv",
-        )
+        x: Path.cwd()
+        / "seqdb"
+        / "data"
+        / "extract"
+        / f"seqdb.src.seq.taxon.{x.lower()}.tsv"
         for x in ["CREATED", "UPDATED", "DELETED"]
     }
     # Retrieve NCBI taxonomy data, parse it, and compare it with the current seqdb taxonomy
@@ -372,7 +372,7 @@ def parse_ncbi_taxonomy(update_ncbi_database: bool = False) -> None:
     get_ncbi_taxon_subset(ncbi_df)
     # # TODO: Temporary read in to facilitate debugging
     # ncbi_df = pd.read_pickle(
-    #     os.path.join(os.environ["XDG_DATA_HOME"], "ncbi_taxonomy.pkl")
+    #     Path(os.environ["XDG_DATA_HOME"]) / "ncbi_taxonomy.pkl"
     # )
     seqdb_df = retrieve_seqdb_taxon(seqdb_taxon_file)
     seqdb_changes = get_seqdb_taxon_changes(seqdb_df, ncbi_df)
@@ -385,7 +385,7 @@ def parse_ncbi_taxonomy(update_ncbi_database: bool = False) -> None:
         df.to_csv(out_files[key], index=False, sep="\t", na_rep="")
     # TODO: Temporary write out to facilitate debugging
     # ncbi_df.to_csv(
-    #     os.path.join(os.environ["XDG_DATA_HOME"], "ncbi_taxonomy.tsv"),
+    #     Path(os.environ["XDG_DATA_HOME"]) / "ncbi_taxonomy.tsv",
     #     index=False,
     #     sep="\t",
     # )

--- a/util/util.py
+++ b/util/util.py
@@ -1,8 +1,8 @@
 import importlib
 import json
-import os
 import uuid
 from enum import Enum
+from pathlib import Path
 from typing import Any, Hashable, Iterable, Type
 
 import ulid
@@ -74,24 +74,24 @@ def update_cfg_from_file(
                 cfg[key] = value
 
     # Get list of files
-    if os.path.isfile(file_or_dir):
+    if Path(file_or_dir).is_file():
         files = [file_or_dir]
-    elif os.path.isdir(file_or_dir):
-        files = [os.path.join(file_or_dir, x) for x in os.listdir(file_or_dir)]
+    elif Path(file_or_dir).is_dir():
+        files = [str(Path(file_or_dir) / x) for x in Path(file_or_dir).iterdir()]
     else:
         raise ValueError(f"Invalid file_or_dir: {file_or_dir}")
 
     # Read files into new_cfg
     new_cfg: dict[str, Any] = {}
     for file in files:
-        name = os.path.basename(file)
+        name = Path(file).name
         keys = [cfg_key_map.get(x, x) for x in name.split(file_key_delimiter)]
         curr_cfg = new_cfg
         for key in keys[0:-1]:
             if key not in curr_cfg:
                 curr_cfg[key] = {}
             curr_cfg = curr_cfg[key]
-        with open(os.path.join(file), "r") as handle:
+        with open(Path(file), "r") as handle:
             try:
                 value = json.load(handle)
             except json.JSONDecodeError as e:

--- a/util/version.py
+++ b/util/version.py
@@ -1,7 +1,15 @@
+"""Retrieve the project version from the pyproject.toml file."""
+
 import tomllib
 
 
 def get_project_version():
+    """Retrieve the project version from the pyproject.toml file.
+    Must be run from the project root directory.
+
+    Returns:
+        str: The version of the project as specified in pyproject.toml.
+    """
     pyproject_path = "pyproject.toml"
 
     with open(pyproject_path, "rb") as f:

--- a/util/version.py
+++ b/util/version.py
@@ -1,0 +1,10 @@
+import tomllib
+
+
+def get_project_version():
+    pyproject_path = "pyproject.toml"
+
+    with open(pyproject_path, "rb") as f:
+        pyproject_data = tomllib.load(f)
+
+    return pyproject_data["project"]["version"]

--- a/util/wgmlst.py
+++ b/util/wgmlst.py
@@ -53,7 +53,7 @@ def parse_alleles() -> None:
     Create a table with one allele per row and with columns locus_set_id, locus_code,
     allele_code, allele_id, seq_hash_sha256.
     """
-    tgt_file = os.path.join(os.getcwd(), "util", "data", "alleles.pkl.gz")
+    tgt_file = Path.cwd() / "util" / "data" / "alleles.pkl.gz"
     # Go over each allele file
     # dfs = []
     for file_data in ALLELE_FILES:


### PR DESCRIPTION
In this PR, all os.path related operations are replaced with Pathlib 'Path()' in the modules:

- test/
- util/
- some loose files (app.py, repository.py)

Concrete the following functions are replaced:

os.path.join -> Path() /
os.path.isfile -> Path().is_file()
os.path.isdir -> Path().is_dir()
os.path.exists -> Path().exists()
os.getcwd -> Path.cwd()
os.remove -> Path().unlink()
os.makedirs -> Path().mkdir()
os.path.dirname -> Path().parent
os.path.basename -> Path().name
os.listdir -> Path().iterdir()
os.path.getmtime -> Path().stat().st_mtime
os.path.splitext -> Path().stem / Path().suffix

Just before the changes were made, all tests were run, and test 'test/casedb/integration/case_access/test_case_access.py::TestCaseAccess::test_case_access' failed. This remained unchanged after the changes.