### PR TITLE
feat(exc): Add ForeignKeyConstraint409HTTPException for handling FK constraint violations

### DIFF
--- a/gen_epix/common/api/exc.py
+++ b/gen_epix/common/api/exc.py
@@ -10,6 +10,7 @@ from gen_epix.fastapp.exc import (
     DomainException,
     DuplicateIdsError,
     IdsError,
+    LinkConstraintViolationError,
     ServiceException,
 )
 
@@ -79,6 +80,13 @@ def generate_handle_exception_function(
         # Raise HTTP exception
         if isinstance(exception, DomainException):
             if isinstance(exception, IdsError):
+                # FK constraint violation: geef 409 terug
+                if isinstance(exception, LinkConstraintViolationError):
+                    if logger:
+                        logger.info(log_message)
+                    raise api_exc.ForeignKeyConstraint409HTTPException(
+                        detail=str(exception)
+                    ) from exception
                 invalid_ids = []
                 if request_ids and exception.ids:
                     # Compare ids received in request with those reported

--- a/gen_epix/fastapp/api/exc.py
+++ b/gen_epix/fastapp/api/exc.py
@@ -90,6 +90,19 @@ class ResourceAlreadyExists409HTTPException(HTTPException):
         )
 
 
+class ForeignKeyConstraint409HTTPException(HTTPException):
+    def __init__(
+        self,
+        detail: str = (
+            "Conflict: Cannot delete resource as it is referenced by another resource (foreign key constraint)"
+        ),
+        headers: dict[str, str] | None = None,
+    ):
+        super().__init__(
+            status_code=status.HTTP_409_CONFLICT, detail=detail, headers=headers
+        )
+
+
 class UnprocessableEntity422HTTPException(HTTPException):
     def __init__(
         self,


### PR DESCRIPTION
New exception to improve foreign key constraint violation handling.

- Add ForeignKeyConstraint409HTTPException to manage FK constraint violations
- Update exception handling logic in generate_handle_exception_function to raise the new exception This change ensures that foreign key constraint errors are handled consistently and returned with a 409 HTTP status code.

Test for example with: `DELETE /v1/organizations/018d074d-e9fc-684c-5815-45bd5761e37c`