### PR TITLE
feat(case): LSP-1355 - Add model validator and unit tests for case type column order

### DIFF
--- a/gen_epix/casedb/domain/model/case/complete_case_type.py
+++ b/gen_epix/casedb/domain/model/case/complete_case_type.py
@@ -1,7 +1,7 @@
 from typing import ClassVar
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from gen_epix.casedb.domain import enum
 from gen_epix.casedb.domain.model.abac.case_abac import (
@@ -56,3 +56,15 @@ class CompleteCaseType(CaseType):
     case_type_share_abacs: dict[UUID, CaseTypeShareAbac] = Field(
         description="The case type share ABAC object by data collection ID"
     )
+
+    @model_validator(mode="after")
+    def derive_case_type_col_order(self) -> "CompleteCaseType":
+        ordered: list[UUID] = []
+        seen: set[UUID] = set()
+        for dim in self.case_type_dims:
+            for cid in dim.case_type_col_order:
+                if cid not in seen:
+                    ordered.append(cid)
+                    seen.add(cid)
+        self.case_type_col_order = ordered
+        return self

--- a/run.py
+++ b/run.py
@@ -485,6 +485,7 @@ class Run:
                 "test/casedb/integration/build_db",
                 "test/casedb/integration/content",
                 "test/casedb/integration/case_access",
+                "test/casedb/unit",
                 # "test/seqdb/integration",
             ]
         )
@@ -501,6 +502,7 @@ class Run:
             + [
                 "test/filter/unit",
                 "test/fastapp/unit",
+                "test/casedb/unit",
             ]
         )
 

--- a/test/casedb/unit/test_case_type_col_order.py
+++ b/test/casedb/unit/test_case_type_col_order.py
@@ -1,0 +1,33 @@
+from uuid import uuid4
+
+from gen_epix.casedb.domain.model.case.case import CaseTypeDim
+from gen_epix.casedb.domain.model.case.complete_case_type import CompleteCaseType
+
+
+def test_case_type_col_order_derivation() -> None:
+    col1, col2, col3, col4 = (uuid4() for _ in range(4))
+
+    dims: list[CaseTypeDim] = [
+        CaseTypeDim(
+            id=uuid4(), dim_id=uuid4(), rank=1, case_type_col_order=[col1, col2]
+        ),
+        CaseTypeDim(id=uuid4(), dim_id=uuid4(), rank=2, case_type_col_order=[col3]),
+        CaseTypeDim(id=uuid4(), dim_id=uuid4(), rank=3, case_type_col_order=[col4]),
+    ]
+
+    complete_case_type = CompleteCaseType(
+        name="test",
+        etiologies={},
+        etiological_agents={},
+        dims={},
+        cols={},
+        case_type_dims=dims,
+        case_type_cols={},
+        case_type_col_order=[col4, col3, col2, col1],
+        genetic_distance_protocols={},
+        tree_algorithms={},
+        case_type_access_abacs={},
+        case_type_share_abacs={},
+    )
+
+    assert complete_case_type.case_type_col_order == [col1, col2, col3, col4]


### PR DESCRIPTION
Implement model validator to derive case type column order based on dimensions
Add unit test for verifying order of case type columns in CompleteCaseType
Include "test/casedb/unit" in test paths

- Model validator automatically sets the case_type_col_order attribute
- Unit test uses uuid4 for unique test case identifiers
- Test coverage improved for case type column order logic

Solves: #LSP-1355