### PR TITLE
refactor: removed unnecessary vscode launch configurations for api

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,32 +32,6 @@
             "justMyCode": true
         },
         {
-            "name": "api.casedb.local.no_ssl",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "run.py",
-            "args": [
-                "api",
-                "casedb",
-                "local",
-                "no_ssl"
-            ],
-            "justMyCode": true
-        },
-        {
-            "name": "api.casedb.local.no_auth",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "run.py",
-            "args": [
-                "api",
-                "casedb",
-                "local",
-                "no_auth"
-            ],
-            "justMyCode": true
-        },
-        {
             "name": "api.casedb.local.debug",
             "type": "debugpy",
             "request": "launch",
@@ -67,19 +41,6 @@
                 "casedb",
                 "local",
                 "debug"
-            ],
-            "justMyCode": true
-        },
-        {
-            "name": "api.casedb.remote",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "run.py",
-            "args": [
-                "api",
-                "casedb",
-                "remote",
-                "idps"
             ],
             "justMyCode": true
         },
@@ -111,32 +72,6 @@
             "justMyCode": true
         },
         {
-            "name": "api.seqdb.local.no_ssl",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "run.py",
-            "args": [
-                "api",
-                "seqdb",
-                "local",
-                "no_ssl"
-            ],
-            "justMyCode": true
-        },
-        {
-            "name": "api.seqdb.local.no_auth",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "run.py",
-            "args": [
-                "api",
-                "seqdb",
-                "local",
-                "no_auth"
-            ],
-            "justMyCode": true
-        },
-        {
             "name": "api.seqdb.local.debug",
             "type": "debugpy",
             "request": "launch",
@@ -146,19 +81,6 @@
                 "seqdb",
                 "local",
                 "debug"
-            ],
-            "justMyCode": true
-        },
-        {
-            "name": "api.seqdb.remote",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "run.py",
-            "args": [
-                "api",
-                "seqdb",
-                "remote",
-                "idps"
             ],
             "justMyCode": true
         },
@@ -190,32 +112,6 @@
             "justMyCode": true
         },
         {
-            "name": "api.omopdb.local.no_ssl",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "run.py",
-            "args": [
-                "api",
-                "omopdb",
-                "local",
-                "no_ssl"
-            ],
-            "justMyCode": true
-        },
-        {
-            "name": "api.omopdb.local.no_auth",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "run.py",
-            "args": [
-                "api",
-                "omopdb",
-                "local",
-                "no_auth"
-            ],
-            "justMyCode": true
-        },
-        {
             "name": "api.omopdb.local.debug",
             "type": "debugpy",
             "request": "launch",
@@ -225,19 +121,6 @@
                 "omopdb",
                 "local",
                 "debug"
-            ],
-            "justMyCode": true
-        },
-        {
-            "name": "api.omopdb.remote",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "run.py",
-            "args": [
-                "api",
-                "omopdb",
-                "remote",
-                "idps"
             ],
             "justMyCode": true
         },

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ python run.py [service] [app_type] [env_name] [idp_config]
 - `service`: The service to run (api, etl) 
 - `app_type`: Specific configuration for an app type (casedb, seqdb, omopbd)
 - `env_name`: Name of the environment.
-- `idp_config`: Which authentication setting to use (idps, mock_idps, no_auth, debug, no_ssl)
+- `idp_config`: Which authentication setting to use (idps, mock_idps, debug)
 
 ---
 

--- a/gen_epix/common/domain/enum.py
+++ b/gen_epix/common/domain/enum.py
@@ -25,4 +25,3 @@ class AppConfigType(Enum):
     MOCK_IDPS = "mock_idps"
     NO_AUTH = "no_auth"
     DEBUG = "debug"
-    NO_SSL = "no_ssl"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ ulid-py==1.1.0
 # configuration handling
 fire==0.7.1
 dynaconf==3.2.11
+PyYAML==6.0.2
 types-setuptools==80.9.*
 
 # calculation

--- a/run.py
+++ b/run.py
@@ -87,13 +87,6 @@ class Run:
                 extension="idp/identity_providers.json",
             ),
         },
-        (AppType.CASEDB, AppConfigType.NO_SSL): {
-            "IDPS_CONFIG_FILE": ConfigDiscovery.get_config_path(
-                app_type=AppType.CASEDB.value,
-                env_var_substring="IDPS_CONFIG_FILE",
-                extension="idp/identity_providers.json",
-            ),
-        },
         (AppType.SEQDB, AppConfigType.IDPS): {
             "IDPS_CONFIG_FILE": ConfigDiscovery.get_config_path(
                 app_type=AppType.SEQDB.value,
@@ -122,13 +115,6 @@ class Run:
                 extension="idp/identity_providers.json",
             ),
         },
-        (AppType.SEQDB, AppConfigType.NO_SSL): {
-            "IDPS_CONFIG_FILE": ConfigDiscovery.get_config_path(
-                app_type=AppType.SEQDB.value,
-                env_var_substring="IDPS_CONFIG_FILE",
-                extension="idp/identity_providers.json",
-            ),
-        },
         (AppType.OMOPDB, AppConfigType.IDPS): {
             "IDPS_CONFIG_FILE": ConfigDiscovery.get_config_path(
                 app_type=AppType.OMOPDB.value,
@@ -151,13 +137,6 @@ class Run:
             ),
         },
         (AppType.OMOPDB, AppConfigType.DEBUG): {
-            "IDPS_CONFIG_FILE": ConfigDiscovery.get_config_path(
-                app_type=AppType.OMOPDB.value,
-                env_var_substring="IDPS_CONFIG_FILE",
-                extension="idp/identity_providers.json",
-            ),
-        },
-        (AppType.OMOPDB, AppConfigType.NO_SSL): {
             "IDPS_CONFIG_FILE": ConfigDiscovery.get_config_path(
                 app_type=AppType.OMOPDB.value,
                 env_var_substring="IDPS_CONFIG_FILE",
@@ -259,12 +238,8 @@ class Run:
         Run.set_env_variables(app_type, idp_config)
         # Run app
         uri_cfg = Run.APP_URI[app_type]
-        if idp_config not in {AppConfigType.NO_SSL}:
-            ssl_keyfile = Run.APP_SSL_KEYFILE
-            ssl_certfile = Run.APP_SSL_CERTFILE
-        else:
-            ssl_keyfile = None
-            ssl_certfile = None
+        ssl_keyfile = Run.APP_SSL_KEYFILE
+        ssl_certfile = Run.APP_SSL_CERTFILE
         # profiler = pyinstrument.Profiler(async_mode="enabled")
         # profiler.start()
         uvicorn.run(


### PR DESCRIPTION
- Removed unnecessary launch configs for api.casedb, api.seqdb, and api.omopdb
- Retained only local, debug, and mock variants for each