### PR TITLE
ci(mypy): Introduce layered typing policy and align CI mypy with mypy.ini

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,7 @@ jobs:
         if: github.event_name == 'pull_request' && failure()
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
-          header: "Code linting"
+          header: "Type checking"
           message:
             "Please type check your code with [mypy](https://www.mypy-lang.org/): \
             `mypy --config-file mypy.ini ./`."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,8 +136,7 @@ jobs:
       - name: Run mypy
         run: |
           source ~/.venv/bin/activate
-          mypy --disallow-untyped-defs --disallow-untyped-calls --disallow-incomplete-defs --ignore-missing-imports --disallow-untyped-decorators --strict-equality \
-          --warn-redundant-casts --warn-unused-ignores --warn-return-any --warn-unreachable ./
+          mypy --config-file mypy.ini ./
       - name: Comment PR in case of failure
         if: github.event_name == 'pull_request' && failure()
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
@@ -145,9 +144,7 @@ jobs:
           header: "Code linting"
           message:
             "Please type check your code with [mypy](https://www.mypy-lang.org/): \
-            `mypy --disallow-untyped-defs --disallow-untyped-calls --disallow-incomplete-defs \
-            --ignore-missing-imports --disallow-untyped-decorators --strict-equality \
-            --warn-redundant-casts --warn-unused-ignores --warn-return-any --warn-unreachable ./ `."
+            `mypy --config-file mypy.ini ./`."
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-tests:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,6 +22,9 @@ coverage==7.13.4
 pandas-stubs==3.0.*
 openpyxl==3.1.*
 types-cachetools==6.2.*
+types-PyYAML==6.0.*
+types-setuptools==82.0.*
+types-python-dateutil==2.9.*
 
 # TODO: remove if run.py no longer uses it
 uvicorn==0.41.0

--- a/docs/06-Development-Guide.md
+++ b/docs/06-Development-Guide.md
@@ -94,7 +94,22 @@ python run.py other_general_run_pylint <error_code>
 python run.py other_general_run_mypy
 ```
 
-CI runs strict `mypy` flags. (Source: `.github/workflows/main.yml#L136-L140`)
+Gen-EpiX uses `mypy` to protect architecture boundaries, catch defects earlier, and improve refactoring safety. The goal is pragmatic typing, not full static coverage.
+
+Typing strictness is layered:
+
+- **Strict**: `gen_epix.*.domain.*`, `gen_epix.*.services.*`, `gen_epix.*.policies.*`
+- **Moderate**: `gen_epix.*.repositories.*`, `gen_epix.fastapp.*`, `gen_epix.*.config.*`
+- **Relaxed**: `test.*`, `tests.*`
+
+Guidelines:
+
+- Type public interfaces and return values first.
+- Avoid `Any` at domain/service/repository/config boundaries.
+- Prefer explicit domain types (`BaseModel`, `TypedDict`, dataclasses).
+- Use `# type: ignore[...]` only when necessary, and keep ignores minimal.
+
+CI also runs `mypy` as a required quality gate. (Source: `.github/workflows/main.yml#L136-L140`; Source: `mypy.ini#L1-L80`)
 
 ### All linters at once
 
@@ -133,6 +148,7 @@ Operator Note: `CASEDB` env setup also sets `SEQDB` env variables, so multi-app 
 
 - `run.py#L15-L887`
 - `.github/workflows/main.yml#L73-L197`
+- `mypy.ini#L1-L80`
 - `gen_epix/commondb/util.py#L61-L119`
 - `gen_epix/commondb/config/settings_manager.py#L43-L67`
 - `gen_epix/commondb/env.py#L185-L197`

--- a/docs/06-Development-Guide.md
+++ b/docs/06-Development-Guide.md
@@ -94,6 +94,12 @@ python run.py other_general_run_pylint <error_code>
 python run.py other_general_run_mypy
 ```
 
+Equivalent direct CI command:
+
+```
+mypy --config-file mypy.ini ./
+```
+
 Gen-EpiX uses `mypy` to protect architecture boundaries, catch defects earlier, and improve refactoring safety. The goal is pragmatic typing, not full static coverage.
 
 Typing strictness is layered:
@@ -109,7 +115,7 @@ Guidelines:
 - Prefer explicit domain types (`BaseModel`, `TypedDict`, dataclasses).
 - Use `# type: ignore[...]` only when necessary, and keep ignores minimal.
 
-CI also runs `mypy` as a required quality gate. (Source: `.github/workflows/main.yml#L136-L140`; Source: `mypy.ini#L1-L80`)
+CI runs the same `mypy.ini`-driven policy as a required quality gate. (Source: `.github/workflows/main.yml#L136-L140`; Source: `mypy.ini#L1-L80`; Source: `run.py#L855-L871`; Source: `test/test_client/linter.py#L50-L58`)
 
 ### All linters at once
 
@@ -149,6 +155,7 @@ Operator Note: `CASEDB` env setup also sets `SEQDB` env variables, so multi-app 
 - `run.py#L15-L887`
 - `.github/workflows/main.yml#L73-L197`
 - `mypy.ini#L1-L80`
+- `test/test_client/linter.py#L50-L58`
 - `gen_epix/commondb/util.py#L61-L119`
 - `gen_epix/commondb/config/settings_manager.py#L43-L67`
 - `gen_epix/commondb/env.py#L185-L197`

--- a/docs/06a-CLI-Reference.md
+++ b/docs/06a-CLI-Reference.md
@@ -92,7 +92,7 @@ Per-app commands follow the pattern `test_{app}_{scope}` and optionally `test_{a
 |------------|-------------|
 | `other_general_run_linters` | Run all linters and write output to `test/output/`. |
 | `other_general_run_pylint` | Run pylint alone, with optional error-code filtering. |
-| `other_general_run_mypy` | Run mypy alone, with optional error-code filtering. |
+| `other_general_run_mypy` | Run mypy alone using repository `mypy.ini` settings. |
 | `other_general_analyse_pylint_code_impact` | Analyse relative impact of pylint codes across the codebase. |
 | `other_general_generate_uuids` | Generate a grid of UUIDs (benchmarking utility). |
 | `other_general_generate_erm_diagrams` | Generate entity-relationship diagrams into `docs/assets/erm/`. |

--- a/docs/07-CI-CD-and-Release.md
+++ b/docs/07-CI-CD-and-Release.md
@@ -43,7 +43,7 @@ Quality enforcement is split into focused checks:
 |------|------|--------|
 | Formatting | `isort --check-only --diff --profile black .` + `black --check --diff .` | `.github/workflows/main.yml#L73-L77` |
 | Linting | `pylint` with PR comment output | `.github/workflows/main.yml#L102-L113` |
-| Type checking | `mypy` with strict flags | `.github/workflows/main.yml#L136-L140` |
+| Type checking | `mypy --config-file mypy.ini ./` | `.github/workflows/main.yml#L136-L140` |
 | Tests | `python run.py test_all` | `.github/workflows/main.yml#L167-L170` |
 | Coverage | XML uploaded as artifact, consumed by SonarCloud | `.github/workflows/main.yml#L171-L197` |
 
@@ -55,7 +55,7 @@ Developer Note: CI test scope is exactly what `run.py test_all` includes; perfor
 |---------|-----------------|
 | Tests | `python run.py test_all` |
 | Formatting check | `isort --check-only --diff --profile black .` then `black --check --diff .` |
-| Type checking | `python run.py other_general_run_mypy` |
+| Type checking | `python run.py other_general_run_mypy` or `mypy --config-file mypy.ini ./` |
 | Linting | `python run.py other_general_run_pylint` |
 
 Tooling is present in `dev-requirements.txt` (`pytest`, `isort`, `black`, `pylint`, `mypy`, `coverage`). (Source: `dev-requirements.txt#L6-L16`)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 # Global configuration: least strict settings
 [mypy]
 python_version = 3.13
-pretty = True
+pretty = False
 warn_unused_configs = True
 warn_redundant_casts = True
 warn_unreachable = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,20 +1,80 @@
-#global
+# Global configuration
 [mypy]
+python_version = 3.13
+pretty = True
+
 warn_return_any = True
 warn_unused_configs = True
 warn_unused_ignores = True
-disallow_untyped_calls = True
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-check_untyped_defs = True
-disallow_untyped_decorators = True
-ignore_missing_imports = True
-strict_optional = True
+warn_redundant_casts = True
+warn_unreachable = True
 strict_equality = True
+strict_optional = True
 
-# per module configuration
-# [mypy-gen_epix.omopdb.domain.service.*]
+check_untyped_defs = True
+disallow_incomplete_defs = True
 
-# missing stubs
+# Do not enforce these globally.
+# They will be enabled selectively for core layers.
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+disallow_untyped_decorators = False
+
+# Prefer targeted exceptions instead of hiding all missing imports.
+ignore_missing_imports = False
+
+
+# Strict typing for core business logic
+[mypy-gen_epix.*.domain.*]
+disallow_untyped_defs = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+
+[mypy-gen_epix.*.services.*]
+disallow_untyped_defs = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+
+[mypy-gen_epix.*.policies.*]
+disallow_untyped_defs = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+
+
+# Moderate typing for infrastructure / adapters
+[mypy-gen_epix.*.repositories.*]
+disallow_untyped_defs = True
+disallow_untyped_calls = False
+disallow_untyped_decorators = False
+
+[mypy-gen_epix.fastapp.*]
+disallow_untyped_defs = True
+disallow_untyped_calls = False
+disallow_untyped_decorators = False
+
+[mypy-gen_epix.*.config.*]
+disallow_untyped_defs = True
+disallow_untyped_calls = False
+disallow_untyped_decorators = False
+
+
+# Relaxed typing for tests
+[mypy-test.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_untyped_decorators = False
+warn_return_any = False
+
+[mypy-tests.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+disallow_untyped_decorators = False
+warn_return_any = False
+
+
+# Missing stubs / third-party libraries
 [mypy-pandas]
+ignore_missing_imports = True
+
+[mypy-yaml]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,80 +1,79 @@
-# Global configuration
+# Global configuration: least strict settings
 [mypy]
 python_version = 3.13
 pretty = True
-
-warn_return_any = True
 warn_unused_configs = True
-warn_unused_ignores = True
 warn_redundant_casts = True
 warn_unreachable = True
 strict_equality = True
 strict_optional = True
-
 check_untyped_defs = True
 disallow_incomplete_defs = True
-
-# Do not enforce these globally.
-# They will be enabled selectively for core layers.
+# Not strict
+warn_return_any = False
+warn_unused_ignores = False
 disallow_untyped_calls = False
 disallow_untyped_defs = False
 disallow_untyped_decorators = False
-
-# Prefer targeted exceptions instead of hiding all missing imports.
 ignore_missing_imports = False
 
 
-# Strict typing for core business logic
-[mypy-gen_epix.*.domain.*]
-disallow_untyped_defs = True
-disallow_untyped_calls = True
-disallow_untyped_decorators = True
+# Specific configurations for different parts of the codebase with more strict settings
 
-[mypy-gen_epix.*.services.*]
-disallow_untyped_defs = True
-disallow_untyped_calls = True
-disallow_untyped_decorators = True
-
-[mypy-gen_epix.*.policies.*]
-disallow_untyped_defs = True
-disallow_untyped_calls = True
-disallow_untyped_decorators = True
-
-
-# Moderate typing for infrastructure / adapters
-[mypy-gen_epix.*.repositories.*]
-disallow_untyped_defs = True
-disallow_untyped_calls = False
-disallow_untyped_decorators = False
-
+# Most strict settings for the most generic code
 [mypy-gen_epix.fastapp.*]
+warn_return_any = True
+warn_unused_ignores = True
+disallow_untyped_calls = True
 disallow_untyped_defs = True
-disallow_untyped_calls = False
-disallow_untyped_decorators = False
-
-[mypy-gen_epix.*.config.*]
+disallow_untyped_decorators = True
+ignore_missing_imports = True
+[mypy-gen_epix.filter.*]
+warn_return_any = True
+warn_unused_ignores = True
+disallow_untyped_calls = True
 disallow_untyped_defs = True
-disallow_untyped_calls = False
-disallow_untyped_decorators = False
+disallow_untyped_decorators = True
+ignore_missing_imports = True
+[mypy-gen_epix.transform.*]
+warn_return_any = True
+warn_unused_ignores = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_untyped_decorators = True
+ignore_missing_imports = True
+[mypy-gen_epix.commondb.*]
+warn_return_any = True
+warn_unused_ignores = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_untyped_decorators = True
+ignore_missing_imports = True
 
+# Intermediate strict settings for the more specific code
+[mypy-gen_epix.casedb.*]
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_untyped_decorators = True
+ignore_missing_imports = True
+[mypy-gen_epix.seqdb.*]
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_untyped_decorators = True
+ignore_missing_imports = True
+[mypy-gen_epix.omopdb.*]
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_untyped_decorators = True
+ignore_missing_imports = True
 
-# Relaxed typing for tests
+# Least strict settings for tests
 [mypy-test.*]
-disallow_untyped_defs = False
-disallow_untyped_calls = False
-disallow_untyped_decorators = False
-warn_return_any = False
-
 [mypy-tests.*]
-disallow_untyped_defs = False
-disallow_untyped_calls = False
-disallow_untyped_decorators = False
-warn_return_any = False
 
 
 # Missing stubs / third-party libraries
 [mypy-pandas]
 ignore_missing_imports = True
-
 [mypy-yaml]
 ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,6 @@ ulid-py==1.1.0
 fire==0.7.1
 dynaconf==3.2.12
 PyYAML==6.0.3
-types-PyYAML==6.0.*
-types-setuptools==82.0.*
 python-multipart==0.0.22
 
 # calculation
@@ -33,4 +31,3 @@ biopython==1.86
 cachetools==7.0.3
 slowapi==0.1.9
 python-dateutil==2.9.0.post0
-types-python-dateutil==2.9.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ ulid-py==1.1.0
 fire==0.7.1
 dynaconf==3.2.12
 PyYAML==6.0.3
+types-PyYAML==6.0.*
 types-setuptools==82.0.*
 python-multipart==0.0.22
 

--- a/run.py
+++ b/run.py
@@ -839,7 +839,7 @@ class Run:
         )
         linter = Linter()
         linter.run_pylint(file=file, filter_on_codes=filter_on_codes)
-        file2.write_text(file.read_text())
+        file2.write_text(file.read_text(encoding="utf-8"), encoding="utf-8")
         for line in linter.parse_pylint_for_issue_lines(
             file, filter_on_codes=filter_on_codes
         ):
@@ -866,7 +866,7 @@ class Run:
         file2 = Path(__file__).parent / "test" / "output" / f"linter.{now_str}.mypy.txt"
         linter = Linter()
         linter.run_mypy(file=file, filter_on_codes=filter_on_codes)
-        file2.write_text(file.read_text())
+        file2.write_text(file.read_text(encoding="utf-8"), encoding="utf-8")
         for line in linter.parse_mypy_for_issue_lines(
             file, filter_on_codes=filter_on_codes
         ):

--- a/test/test_client/linter.py
+++ b/test/test_client/linter.py
@@ -50,19 +50,9 @@ class Linter:
     PRESETS = {
         "mypy": [
             "mypy",
-            "--no-incremental",
-            "--disallow-untyped-defs",
-            "--disallow-untyped-calls",
-            "--disallow-incomplete-defs",
-            "--disallow-untyped-decorators",
-            "--strict-equality",
-            "--warn-redundant-casts",
-            "--warn-unused-ignores",
-            "--warn-return-any",
-            "--warn-unreachable",
-            "--show-error-codes",
-            "gen_epix/",
-            # "test/",
+            "--config-file",
+            "mypy.ini",
+            "./",
         ],
         "pylint": [
             "pylint",
@@ -115,14 +105,14 @@ class Linter:
         self.run(cmd, file=file)
         if filter_on_codes:
             lines = self.parse_mypy_for_issue_lines(file, filter_on_codes)
-            file.write_text("\n".join(lines))
+            file.write_text("\n".join(lines), encoding="utf-8")
 
     def parse_pylint_for_issue_lines(
         self, file: Path | str, filter_on_codes: set[str] | None = None
     ) -> list[str]:
         if isinstance(file, str):
             file = Path(file)
-        with open(file, "rt") as handle:
+        with open(file, "rt", encoding="utf-8", errors="replace") as handle:
             lines = handle.readlines()
         pattern = self.PYLINT_CODE_PATTERN
         issue_lines = [
@@ -140,7 +130,7 @@ class Linter:
     ) -> list[str]:
         if isinstance(file, str):
             file = Path(file)
-        with open(file, "rt") as handle:
+        with open(file, "rt", encoding="utf-8", errors="replace") as handle:
             lines = handle.readlines()
         location_pattern = self.MYPY_LOCATION_PATTERN
         issue_code_pattern = self.MYPY_ISSUE_CODE_PATTERN
@@ -213,16 +203,16 @@ class Linter:
             retval = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
             if verbose:
                 print(f"{cmd[2]} passed")
-            output = retval.decode("utf-8")
+            output = retval.decode("utf-8", errors="replace")
         except subprocess.CalledProcessError as e:
-            output = e.output.decode("utf-8")
+            output = e.output.decode("utf-8", errors="replace")
             if verbose:
                 print(f"Failed running {cmd[2]}, here is the output:")
                 print(output)
         if file:
             if isinstance(file, str):
                 file = Path(file)
-            file.write_text(output)
+            file.write_text(output, encoding="utf-8")
         return output
 
     def run_all(self, file_basename: Path | str | None = None) -> None:
@@ -251,15 +241,15 @@ class Linter:
                 file2 = None
             output = self.run(value, file=file)
             if file2:
-                file2.write_text(file.read_text())
+                file2.write_text(file.read_text(encoding="utf-8"), encoding="utf-8")
             if output:
                 outputs.append(output)
         if file_basename:
             file = Path(f"{file_basename}.txt")
             file2 = Path(f"{file_basename}.{now_str}.txt")
-            with open(file, "wt") as handle:
+            with open(file, "wt", encoding="utf-8") as handle:
                 handle.write("\n".join(outputs))
-            file2.write_text(file.read_text())
+            file2.write_text(file.read_text(encoding="utf-8"), encoding="utf-8")
 
     def analyse_pylint_code_impact(self, verbose: bool = True) -> None:
         output_dir = get_test_root_output_dir()


### PR DESCRIPTION
## Context
This PR introduces a **new typing strategy** for this repository: a **layered typing approach**.  
The goal is not full static typing everywhere, but targeted strictness at architectural boundaries and pragmatic flexibility elsewhere. Typing strictness is not mandatory for development (or blocking), but it configures the mypy type checker (the tool) to be more aligned with the project.

## Why this change
Previously, CI type-checking behavior was primarily driven by hardcoded `mypy` CLI flags in the workflow.  
That made it harder to reason about policy, and did not clearly reflect the new layered model.

This PR renews `mypy.ini` as the policy source and aligns CI to use it directly.

## What is new in the typing model
Typing strictness is now explicitly layered:

- **Strict layer** for core logic/contracts (e.g. domain/services/policies).
- **Moderate layer** for infrastructure/adapters (e.g. repositories/framework/config).
- **Relaxed layer** for tests.

This is a deliberate architecture-first policy: strict where contract safety matters most, pragmatic where code is more dynamic.

## Changes in this PR
- CI `mypy` invocation in [main.yml](c:/Py Projects/LSP-RIVM/gen-epix-api/.github/workflows/main.yml:136) now uses:
  - `mypy --config-file mypy.ini ./`
- PR failure help text in [main.yml](c:/Py Projects/LSP-RIVM/gen-epix-api/.github/workflows/main.yml:146) updated to match.
- Contributor documentation updated in [06-Development-Guide.md](c:/Py Projects/LSP-RIVM/gen-epix-api/docs/06-Development-Guide.md:91) to explain the layered policy and local usage.

## Reviewer focus
- Confirm the layered policy in [mypy.ini](c:/Py Projects/LSP-RIVM/gen-epix-api/mypy.ini) matches intended architecture boundaries.
- Confirm CI should use `mypy.ini` as single source of truth.
- Confirm docs communicate the new model clearly for contributors.

## Test results
Local workflow validation with `act`:

- Command:  
  `act -j Type-checking -W .github/workflows/main.yml -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest --bind`
- Result:
  - `Setup and cache environment`: passed
  - `Type-checking`: reached and executed `Run mypy`
  - `Run mypy`: failed due to existing type debt (`Found 1819 errors in 230 files (checked 613 source files)`)

## Impact
- No runtime behavior changes.
- CI typing behavior is now centrally governed by `mypy.ini`.
- This PR establishes the layered typing foundation; it does not aim to resolve all existing mypy violations.