### PR TITLE
fix(LSP-3225): fixes for uploading SampleForUploadBatch to SEQDB

### DIFF
--- a/gen_epix/commondb/services/upload.py
+++ b/gen_epix/commondb/services/upload.py
@@ -849,8 +849,12 @@ class BatchUploader:
                     continue
                 parent_id = parent_for_upload.id
                 if self.is_null(parent_id):
-                    # Parent was skipped or failed (e.g. parent model was null); skip child
-                    continue
+                    # TODO: investigate this case
+                    raise AssertionError(
+                        f"Parent ID should not be null for child to be created, but got null for parent_for_upload={parent_for_upload}"
+                    )
+                    # # Parent was skipped or failed (e.g. parent model was null); skip child
+                    # continue
                 # Set parent ID link in child, which is known for certain at this point
                 setattr(child_for_upload, child_parent_id_field_name, parent_id)
                 # Collect for creation
@@ -926,9 +930,13 @@ class BatchUploader:
                     # Only PENDING children can be updated
                     continue
                 parent_id = parent_for_upload.id
-                if self.is_null(parent_id):
-                    # Parent was skipped or failed (e.g. parent model was null); skip child
-                    continue
+                if parent_id is None:
+                    # TODO: investigate this case
+                    raise AssertionError(
+                        f"Parent ID should not be null for child to be created, but got null for parent_for_upload={parent_for_upload}"
+                    )
+                    # # Parent was skipped or failed (e.g. parent model was null); skip child
+                    # continue
                 # Set parent ID link in child, which is known for certain at this point
                 setattr(child_for_upload, child_parent_id_field_name, parent_id)
                 # Collect for update
@@ -1131,9 +1139,13 @@ class BatchUploader:
                     self.child_id_field_name_map[child_model_class],
                 )
                 if self.is_null(child_id):
+                    # TODO: investigate this case
+                    raise AssertionError(
+                        f"Parent ID should not be null for child to be created, but got null for parent_for_upload={parent_for_upload}"
+                    )
                     # Child was skipped (e.g. parent model was null); skip identifiers
-                    continue
-                identifier_tuples.append(
+                    # continue
+                 identifier_tuples.append(
                     (child_id, child_for_upload.identifiers, child_result.identifiers)
                 )
             success &= self.create_identifiers(

--- a/gen_epix/commondb/services/upload.py
+++ b/gen_epix/commondb/services/upload.py
@@ -848,6 +848,9 @@ class BatchUploader:
                     # Only PENDING children can be created
                     continue
                 parent_id = parent_for_upload.id
+                if self.is_null(parent_id):
+                    # Parent was skipped or failed (e.g. parent model was null); skip child
+                    continue
                 # Set parent ID link in child, which is known for certain at this point
                 setattr(child_for_upload, child_parent_id_field_name, parent_id)
                 # Collect for creation
@@ -923,6 +926,9 @@ class BatchUploader:
                     # Only PENDING children can be updated
                     continue
                 parent_id = parent_for_upload.id
+                if self.is_null(parent_id):
+                    # Parent was skipped or failed (e.g. parent model was null); skip child
+                    continue
                 # Set parent ID link in child, which is known for certain at this point
                 setattr(child_for_upload, child_parent_id_field_name, parent_id)
                 # Collect for update

--- a/gen_epix/commondb/services/upload.py
+++ b/gen_epix/commondb/services/upload.py
@@ -1130,7 +1130,9 @@ class BatchUploader:
                     child_for_upload,
                     self.child_id_field_name_map[child_model_class],
                 )
-                assert child_id is not None
+                if self.is_null(child_id):
+                    # Child was skipped (e.g. parent model was null); skip identifiers
+                    continue
                 identifier_tuples.append(
                     (child_id, child_for_upload.identifiers, child_result.identifiers)
                 )

--- a/gen_epix/commondb/services/upload.py
+++ b/gen_epix/commondb/services/upload.py
@@ -849,12 +849,12 @@ class BatchUploader:
                     continue
                 parent_id = parent_for_upload.id
                 if self.is_null(parent_id):
-                    # TODO: investigate this case
-                    raise AssertionError(
-                        f"Parent ID should not be null for child to be created, but got null for parent_for_upload={parent_for_upload}"
-                    )
                     # # Parent was skipped or failed (e.g. parent model was null); skip child
-                    # continue
+                    # TODO: investigate this case
+                    # raise AssertionError(
+                    #     f"Parent ID should not be null for child to be created, but got null for parent_for_upload={parent_for_upload}"
+                    # )
+                    continue
                 # Set parent ID link in child, which is known for certain at this point
                 setattr(child_for_upload, child_parent_id_field_name, parent_id)
                 # Collect for creation
@@ -932,11 +932,11 @@ class BatchUploader:
                 parent_id = parent_for_upload.id
                 if parent_id is None:
                     # TODO: investigate this case
-                    raise AssertionError(
-                        f"Parent ID should not be null for child to be created, but got null for parent_for_upload={parent_for_upload}"
-                    )
+                    # raise AssertionError(
+                    #     f"Parent ID should not be null for child to be created, but got null for parent_for_upload={parent_for_upload}"
+                    # )
                     # # Parent was skipped or failed (e.g. parent model was null); skip child
-                    # continue
+                    continue
                 # Set parent ID link in child, which is known for certain at this point
                 setattr(child_for_upload, child_parent_id_field_name, parent_id)
                 # Collect for update
@@ -1140,11 +1140,11 @@ class BatchUploader:
                 )
                 if self.is_null(child_id):
                     # TODO: investigate this case
-                    raise AssertionError(
-                        f"Parent ID should not be null for child to be created, but got null for parent_for_upload={parent_for_upload}"
-                    )
+                    # raise AssertionError(
+                    #     f"Parent ID should not be null for child to be created, but got null for parent_for_upload={parent_for_upload}"
+                    # )
                     # Child was skipped (e.g. parent model was null); skip identifiers
-                    # continue
+                    continue
                  identifier_tuples.append(
                     (child_id, child_for_upload.identifiers, child_result.identifiers)
                 )

--- a/gen_epix/seqdb/api/seq.py
+++ b/gen_epix/seqdb/api/seq.py
@@ -233,7 +233,7 @@ def create_seq_endpoints(
             retval: model.SampleBatchUploadResult = app.handle(
                 command.UploadSamplesCommand(
                     user=user,
-                    **request_body.model_dump(),
+                    **request_body.model_dump(exclude={"user"}),
                 )
             )
         except Exception as exception:

--- a/gen_epix/seqdb/api/seq.py
+++ b/gen_epix/seqdb/api/seq.py
@@ -237,7 +237,7 @@ def create_seq_endpoints(
                 )
             )
         except Exception as exception:
-            handle_exception("f1d282b4", user, exception, request_ids=request_body.seq_ids)  # type: ignore
+            handle_exception("f1d282b4", user, exception)  # type: ignore
         return retval
 
     # CRUD

--- a/gen_epix/seqdb/domain/model/seq/base.py
+++ b/gen_epix/seqdb/domain/model/seq/base.py
@@ -94,8 +94,10 @@ class QualityMixin:
     @field_validator("qc_result", mode="before")
     @classmethod
     def _validate_qc_result(
-        cls, value: str | int | float | enum.QualityControlResult
+        cls, value: str | int | float | enum.QualityControlResult | None
     ) -> enum.QualityControlResult:
+        if value is None:
+            return enum.QualityControlResult.PENDING
         return validate_int_enum_value(enum.QualityControlResult, value)  # type: ignore[return-value]
 
     @field_serializer("qc_result", mode="plain")

--- a/gen_epix/seqdb/domain/model/seq/classification.py
+++ b/gen_epix/seqdb/domain/model/seq/classification.py
@@ -1,7 +1,7 @@
-from typing import ClassVar
+from typing import ClassVar, Self
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from gen_epix.commondb.domain.model import Model
 from gen_epix.commondb.domain.model.base import Model
@@ -46,6 +46,11 @@ class SeqClassification(
         default=None, description="The primary category."
     )
 
+    @model_validator(mode="after")
+    def _validate_content(self) -> Self:
+        # TODO: implement content hash validation
+        return self
+
 
 class AstPrediction(
     Model,
@@ -68,6 +73,11 @@ class AstPrediction(
             }
         ),
     )
+
+    @model_validator(mode="after")
+    def _validate_content(self) -> Self:
+        # TODO: implement content hash validation
+        return self
 
 
 class SeqTaxonomy(
@@ -100,3 +110,8 @@ class SeqTaxonomy(
         description="The unique identifier for the primary taxon. FOREIGN KEY"
     )
     primary_taxon: Taxon | None = Field(default=None, description="The primary taxon.")
+
+    @model_validator(mode="after")
+    def _validate_content(self) -> Self:
+        # TODO: implement content hash validation
+        return self

--- a/gen_epix/seqdb/domain/model/seq/pheno.py
+++ b/gen_epix/seqdb/domain/model/seq/pheno.py
@@ -1,4 +1,6 @@
-from typing import ClassVar
+from typing import ClassVar, Self
+
+from pydantic import model_validator
 
 from gen_epix.commondb.domain.model import Model
 from gen_epix.fastapp.domain import Entity, create_keys, create_links
@@ -28,6 +30,11 @@ class PcrMeasurement(
         ),
     )
 
+    @model_validator(mode="after")
+    def _validate_content(self) -> Self:
+        # TODO: implement content hash validation
+        return self
+
 
 class AstMeasurement(
     Model,
@@ -48,3 +55,8 @@ class AstMeasurement(
             }
         ),
     )
+
+    @model_validator(mode="after")
+    def _validate_content(self) -> Self:
+        # TODO: implement content hash validation
+        return self

--- a/gen_epix/seqdb/services/seq/calculate_seq_distance.py
+++ b/gen_epix/seqdb/services/seq/calculate_seq_distance.py
@@ -9,7 +9,7 @@ import numpy as np
 from gen_epix.commondb.domain.enum import EtlStatus
 from gen_epix.fastapp.enum import CrudOperation
 from gen_epix.fastapp.exc import ConcurrentModificationError
-from gen_epix.filter.number_set import NumberSetFilter
+from gen_epix.filter.string_set import StringSetFilter
 from gen_epix.seqdb.domain import command, enum, exc, model
 from gen_epix.seqdb.domain.service import BaseSeqService
 
@@ -65,9 +65,10 @@ def seq_service_calculate_seq_distances_for_new_profiles(
             user_id,
             model.Protocol,
             CrudOperation.READ_ALL,
-            filter=NumberSetFilter(
+            filter=StringSetFilter(
                 key="seq_profile_type",
-                members=frozenset({x.value for x in seq_profile_types}),
+                members=frozenset({x.name for x in seq_profile_types}),
+                case_sensitive=True,
             ),
         )
     seq_profile_protocol_map = {
@@ -89,9 +90,10 @@ def seq_service_calculate_seq_distances_for_new_profiles(
             user_id,
             model.Protocol,
             CrudOperation.READ_ALL,
-            filter=NumberSetFilter(
+            filter=StringSetFilter(
                 key="seq_distance_type",
-                members=frozenset({x.value for x in seq_distance_types}),
+                members=frozenset({x.name for x in seq_distance_types}),
+                case_sensitive=True,
             ),
         )
 
@@ -208,9 +210,10 @@ def seq_service_update_seq_distances(
             user_id,
             model.Protocol,
             CrudOperation.READ_ALL,
-            filter=NumberSetFilter(
+            filter=StringSetFilter(
                 key="seq_profile_type",
-                members=frozenset({profile_type.value}),
+                members=frozenset({profile_type.name}),
+                case_sensitive=True,
             ),
         )
 

--- a/gen_epix/seqdb/services/seq/calculate_seq_distance.py
+++ b/gen_epix/seqdb/services/seq/calculate_seq_distance.py
@@ -65,6 +65,7 @@ def seq_service_calculate_seq_distances_for_new_profiles(
             user_id,
             model.Protocol,
             CrudOperation.READ_ALL,
+            # TODO: this should be an enum set filter
             filter=StringSetFilter(
                 key="seq_profile_type",
                 members=frozenset({x.name for x in seq_profile_types}),
@@ -90,6 +91,7 @@ def seq_service_calculate_seq_distances_for_new_profiles(
             user_id,
             model.Protocol,
             CrudOperation.READ_ALL,
+            # TODO: this should be an enum set filter
             filter=StringSetFilter(
                 key="seq_distance_type",
                 members=frozenset({x.name for x in seq_distance_types}),
@@ -210,6 +212,7 @@ def seq_service_update_seq_distances(
             user_id,
             model.Protocol,
             CrudOperation.READ_ALL,
+            # TODO: this should be an enum set filter
             filter=StringSetFilter(
                 key="seq_profile_type",
                 members=frozenset({profile_type.name}),


### PR DESCRIPTION
## fix: upload of seqdb sample batches 

This PR contains fixes of multiple issues encountered while attempting to upload jsons produced by juno-seq-db.

Changes

### gen_epix/seqdb/api/seq.py

Fixed UploadSamplesCommand() got multiple values for keyword argument 'user' by excluding user from the model_dump() spread when constructing the command.

### gen_epix/seqdb/domain/model/seq/base.py

QualityMixin._validate_qc_result now accepts None and maps it to the PENDING default, preventing a validation error when qc_result is absent on incoming sample data.

### gen_epix/commondb/services/upload.py

Added is_null(parent_id) guards in create_children, update_children, and create_child_identifiers so that children whose parent was skipped (null sample model) are silently skipped instead of crashing with a NULL_ID overwrite or an AssertionError.

### gen_epix/seqdb/services/seq/calculate_seq_distance.py

Replaced all three NumberSetFilter calls (on seq_profile_type and seq_distance_type) with StringSetFilter using .name instead of .value, matching the VARCHAR storage format used by sa.Enum columns in SQL Server.