### PR TITLE
Lsp 3225 fixes for seqdb to case flow

### DIFF
--- a/gen_epix/casedb/services/case/upload.py
+++ b/gen_epix/casedb/services/case/upload.py
@@ -160,23 +160,25 @@ class CaseBatchUploader(BatchUploader):
         # Merge case content with that already in the database for updates, and
         # validate the merged content again so that there are no inconsistencies
         if cases_for_validation:
-            # Get content of existing cases
+            # Get content of existing cases, keyed by case id to avoid relying on
+            # result ordering from the DB.
             case_ids: list[UUID] = [
                 x.id for x in cases_for_validation  # type: ignore[misc]
             ]
-            existing_content_tuples: list[dict[UUID, str | None] | None] = (
-                self.service.repository.read_fields(  # type: ignore[assignment]
+            existing_content_by_id: dict[UUID, dict] = {
+                row[0]: row[1]
+                for row in self.service.repository.read_fields(
                     uow,
                     None if cmd.user is None else cmd.user.id,
                     model.Case,
-                    ["content"],
+                    ["id", "content"],
                     filter=UuidSetFilter(key="id", members=frozenset(case_ids)),
                 )
-            )
+                if row[1] is not None
+            }
             # Merge new content into existing
-            for case, existing_content in zip(
-                cases_for_validation, existing_content_tuples
-            ):
+            for case in cases_for_validation:
+                existing_content = existing_content_by_id.get(case.id)  # type: ignore[arg-type]
                 if existing_content is None:
                     continue
                 BatchUploader.update_sub_field_dict(existing_content, case.content)

--- a/gen_epix/casedb/services/remote_app.py
+++ b/gen_epix/casedb/services/remote_app.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any
 
-
 from gen_epix.casedb.domain import DOMAIN, command, model
 from gen_epix.commondb.services import CommondbRemoteApp as CommondbRemoteApp
 from gen_epix.fastapp.model import Command
@@ -26,11 +25,10 @@ class CasedbRemoteApp(CommondbRemoteApp):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(DOMAIN, *args, **kwargs)
 
-        # Register routes and handlers
-        self.register_route(
-            command.UploadCasesCommand,
-            self.ROUTE_MAP[command.UploadCasesCommand],
-        )
+        # Register routes
+        for cmd_class, route in self.ROUTE_MAP.items():
+            self.register_route(cmd_class, route)
+        # Register handlers
         self.register_handler(
             command.UploadCasesCommand,
             self.upload_cases,
@@ -42,9 +40,7 @@ class CasedbRemoteApp(CommondbRemoteApp):
     ) -> model.CaseBatchUploadResult:
         headers = self.get_headers(cmd)
         route = self.get_route(cmd)
-
         request_body = cmd
-
         with self.get_client(cmd) as client:
             response = client.post(
                 route,

--- a/gen_epix/commondb/app_setup.py
+++ b/gen_epix/commondb/app_setup.py
@@ -73,6 +73,7 @@ def create_fast_api(
     )
 
     # Add middleware
+    # TODO: make this a feature flag rather than environment variable
     ratelimit_enabled = os.environ.get("RATELIMIT_ENABLED", "1") not in ("0", "false", "False")
     if not debug and ratelimit_enabled:
         # Rate limiting

--- a/gen_epix/commondb/app_setup.py
+++ b/gen_epix/commondb/app_setup.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from collections.abc import Callable
 from typing import Any, NoReturn
 
@@ -72,7 +73,8 @@ def create_fast_api(
     )
 
     # Add middleware
-    if not debug:
+    ratelimit_enabled = os.environ.get("RATELIMIT_ENABLED", "1") not in ("0", "false", "False")
+    if not debug and ratelimit_enabled:
         # Rate limiting
         fast_api.state.limiter = limiter.limiter
         fast_api.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]

--- a/gen_epix/omopdb/services/remote_app.py
+++ b/gen_epix/omopdb/services/remote_app.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any
 
-
 from gen_epix.commondb.services import CommondbRemoteApp as CommondbRemoteApp
 from gen_epix.fastapp.model import Command
 from gen_epix.omopdb.domain import DOMAIN, command, model
@@ -26,11 +25,10 @@ class OmopdbRemoteApp(CommondbRemoteApp):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(DOMAIN, *args, **kwargs)
 
-        # Register routes and handlers
-        self.register_route(
-            command.UploadPersonsCommand,
-            self.ROUTE_MAP[command.UploadPersonsCommand],
-        )
+        # Register routes
+        for cmd_class, route in self.ROUTE_MAP.items():
+            self.register_route(cmd_class, route)
+        # Register handlers
         self.register_handler(
             command.UploadPersonsCommand,
             self.upload_persons,

--- a/gen_epix/seqdb/api/__init__.py
+++ b/gen_epix/seqdb/api/__init__.py
@@ -17,3 +17,9 @@ from gen_epix.seqdb.api.seq import (
     RetrieveSimilarProfilesRequestBody as RetrieveSimilarProfilesRequestBody,
 )
 from gen_epix.seqdb.api.seq import UploadSamplesRequestBody as UploadSamplesRequestBody
+from gen_epix.seqdb.api.seq import (
+    RetrieveBestSeqPerSampleRequestBody as RetrieveBestSeqPerSampleRequestBody,
+)
+from gen_epix.seqdb.api.seq import (
+    RetrieveBestSeqProfilePerSampleRequestBody as RetrieveBestSeqProfilePerSampleRequestBody,
+)

--- a/gen_epix/seqdb/api/seq.py
+++ b/gen_epix/seqdb/api/seq.py
@@ -280,9 +280,9 @@ def create_seq_endpoints(
     async def retrieve__best_seq_per_sample(
         user: registered_user_dependency,  # type: ignore
         request_body: RetrieveBestSeqPerSampleRequestBody,  # type: ignore
-    ) -> list[UUID]:
+    ) -> dict[UUID, UUID]:
         try:
-            retval: list[UUID] = app.handle(
+            retval: dict[UUID, UUID] = app.handle(
                 command.RetrieveBestSeqPerSampleCommand(
                     user=user,
                     protocol_ids=request_body.protocol_ids,
@@ -302,9 +302,9 @@ def create_seq_endpoints(
     async def retrieve__best_seq_profile_per_sample(
         user: registered_user_dependency,  # type: ignore
         request_body: RetrieveBestSeqProfilePerSampleRequestBody,  # type: ignore
-    ) -> list[UUID]:
+    ) -> dict[UUID, UUID]:
         try:
-            retval: list[UUID] = app.handle(
+            retval: dict[UUID, UUID] = app.handle(
                 command.RetrieveBestSeqProfilePerSampleCommand(
                     user=user,
                     protocol_ids=request_body.protocol_ids,

--- a/gen_epix/seqdb/api/seq.py
+++ b/gen_epix/seqdb/api/seq.py
@@ -12,6 +12,7 @@ from gen_epix.commondb.app_impl_details import AppImplDetails
 from gen_epix.fastapp import App
 from gen_epix.fastapp.api import CrudEndpointGenerator
 from gen_epix.seqdb.domain import command, enum, model
+from gen_epix.util import copy_model_field
 
 
 class UploadSamplesRequestBody(command.UploadSamplesCommand):
@@ -47,6 +48,26 @@ class RetrieveSeqFastaRequestBody(PydanticBaseModel):
 
     file_name: str = Field(
         description="The desired filename for the FASTA download.",
+    )
+
+
+class RetrieveBestSeqPerSampleRequestBody(PydanticBaseModel):
+
+    protocol_ids: set[UUID] | None = copy_model_field(
+        command.RetrieveBestSeqPerSampleCommand, "protocol_ids"
+    )
+    sample_ids: set[UUID] | None = copy_model_field(
+        command.RetrieveBestSeqPerSampleCommand, "sample_ids"
+    )
+
+
+class RetrieveBestSeqProfilePerSampleRequestBody(PydanticBaseModel):
+
+    protocol_ids: set[UUID] = copy_model_field(
+        command.RetrieveBestSeqProfilePerSampleCommand, "protocol_ids"
+    )
+    sample_ids: set[UUID] | None = copy_model_field(
+        command.RetrieveBestSeqProfilePerSampleCommand, "sample_ids"
     )
 
 
@@ -249,3 +270,47 @@ def create_seq_endpoints(
     CrudEndpointGenerator.generate_endpoints(
         router, crud_endpoint_sets, handle_exception
     )
+
+    @router.post(
+        "/retrieve/best_seq_per_sample",
+        operation_id="retrieve__best_seq_per_sample",
+        name="RetrieveBestSeqPerSample",
+        description=command.RetrieveBestSeqPerSampleCommand.__doc__,
+    )
+    async def retrieve__best_seq_per_sample(
+        user: registered_user_dependency,  # type: ignore
+        request_body: RetrieveBestSeqPerSampleRequestBody,  # type: ignore
+    ) -> list[UUID]:
+        try:
+            retval: list[UUID] = app.handle(
+                command.RetrieveBestSeqPerSampleCommand(
+                    user=user,
+                    protocol_ids=request_body.protocol_ids,
+                    sample_ids=request_body.sample_ids,
+                )
+            )
+        except Exception as exception:
+            handle_exception("c3f7a9e1", user, exception, request_ids=request_body.sample_ids)  # type: ignore
+        return retval
+
+    @router.post(
+        "/retrieve/best_seq_profile_per_sample",
+        operation_id="retrieve__best_seq_profile_per_sample",
+        name="RetrieveBestSeqProfilePerSample",
+        description=command.RetrieveBestSeqProfilePerSampleCommand.__doc__,
+    )
+    async def retrieve__best_seq_profile_per_sample(
+        user: registered_user_dependency,  # type: ignore
+        request_body: RetrieveBestSeqProfilePerSampleRequestBody,  # type: ignore
+    ) -> list[UUID]:
+        try:
+            retval: list[UUID] = app.handle(
+                command.RetrieveBestSeqProfilePerSampleCommand(
+                    user=user,
+                    protocol_ids=request_body.protocol_ids,
+                    sample_ids=request_body.sample_ids,
+                )
+            )
+        except Exception as exception:
+            handle_exception("e2b4d8f6", user, exception, request_ids=request_body.sample_ids)  # type: ignore
+        return retval

--- a/gen_epix/seqdb/domain/command/__init__.py
+++ b/gen_epix/seqdb/domain/command/__init__.py
@@ -119,6 +119,12 @@ from gen_epix.seqdb.domain.command.seq import (
 )
 from gen_epix.seqdb.domain.command.seq import RefSeqCrudCommand as RefSeqCrudCommand
 from gen_epix.seqdb.domain.command.seq import (
+    RetrieveBestSeqPerSampleCommand as RetrieveBestSeqPerSampleCommand,
+)
+from gen_epix.seqdb.domain.command.seq import (
+    RetrieveBestSeqProfilePerSampleCommand as RetrieveBestSeqProfilePerSampleCommand,
+)
+from gen_epix.seqdb.domain.command.seq import (
     RetrieveSamplesByIdCommand as RetrieveSamplesByIdCommand,
 )
 from gen_epix.seqdb.domain.command.seq import (
@@ -206,6 +212,8 @@ COMMANDS_BY_SERVICE_TYPE: dict[enum.ServiceType, set[type[fastapp.Command]]] = {
         RefAlleleCrudCommand,
         RefSeqCrudCommand,
         CalculatePhylogeneticTreeCommand,
+        RetrieveBestSeqPerSampleCommand,
+        RetrieveBestSeqProfilePerSampleCommand,
         RetrieveSamplesByQueryCommand,
         RetrieveSamplesByIdCommand,
         RetrieveSeqFastaCommand,

--- a/gen_epix/seqdb/domain/command/seq.py
+++ b/gen_epix/seqdb/domain/command/seq.py
@@ -209,8 +209,8 @@ class RetrieveBestSeqPerSampleCommand(Command):
     """
 
     protocol_ids: set[UUID] | None = Field(
+        default=None,
         description="The IDs of the assembly protocols to search among. If None, search among all seqs.",
-        min_length=1,
     )
     sample_ids: set[UUID] | None = Field(
         description="The IDs of the samples to search among. If None, search among all samples.",

--- a/gen_epix/seqdb/domain/command/seq.py
+++ b/gen_epix/seqdb/domain/command/seq.py
@@ -201,6 +201,46 @@ class RetrieveSimilarProfilesCommand(Command):
     )
 
 
+class RetrieveBestSeqPerSampleCommand(Command):
+    """
+    Retrieve the best Seq ID for each sample among the given sample IDs and protocol
+    IDs, and using a particular ranking strategy.
+    Returns a dict[sample_id, seq_id].
+    """
+
+    protocol_ids: set[UUID] | None = Field(
+        description="The IDs of the assembly protocols to search among. If None, search among all seqs.",
+        min_length=1,
+    )
+    sample_ids: set[UUID] | None = Field(
+        description="The IDs of the samples to search among. If None, search among all samples.",
+    )
+    ranking_strategy: enum.SeqProfileRankingStrategy = Field(
+        default=enum.SeqProfileRankingStrategy.QC_RESULT_THEN_SCORE_THEN_CREATED,
+        description="The strategy to use for ranking the profiles. This determines how the best profile is selected.",
+    )
+
+
+class RetrieveBestSeqProfilePerSampleCommand(Command):
+    """
+    Retrieve the best SeqProfile ID for each sample among the given sample IDs and
+    protocol IDs, and using a particular ranking strategy.
+    Returns a dict[sample_id, seq_profile_id].
+    """
+
+    protocol_ids: set[UUID] = Field(
+        description="The IDs of the sequence profile protocols to search among.",
+        min_length=1,
+    )
+    sample_ids: set[UUID] | None = Field(
+        description="The IDs of the samples to search among. If None, search among all samples.",
+    )
+    ranking_strategy: enum.SeqProfileRankingStrategy = Field(
+        default=enum.SeqProfileRankingStrategy.QC_RESULT_THEN_SCORE_THEN_CREATED,
+        description="The strategy to use for ranking the profiles. This determines how the best profile is selected.",
+    )
+
+
 # CRUD commands
 
 

--- a/gen_epix/seqdb/domain/enum.py
+++ b/gen_epix/seqdb/domain/enum.py
@@ -202,6 +202,16 @@ class QualityControlResult(IntEnumWithJsonSchemaMixin, IntEnum):
     def is_usable(self) -> bool:
         return self in {QualityControlResult.PASS, QualityControlResult.WARN}
 
+    def get_sort_key(self) -> int:
+        """
+        Return a sort key for sorting instances of QualityControlResult by the quality
+        level they represent. This is equal to the enum value, but provided as a method
+        for better readability and to encapsulate the logic. Higher values represent
+        better quality, while PENDING has the lowest quality as it is intended as a
+        temporary state.
+        """
+        return self.value
+
 
 class QualityControlResultSet(Enum):
     USABLE = frozenset(
@@ -456,3 +466,11 @@ class FileFormat(IntEnumWithJsonSchemaMixin, IntEnum):
 class FileCompression(IntEnumWithJsonSchemaMixin, IntEnum):
     NONE = 1
     GZIP = 2
+
+
+class SeqRankingStrategy(Enum):
+    QC_RESULT_THEN_SCORE_THEN_CREATED = "QC_RESULT_THEN_SCORE_THEN_CREATED"
+
+
+class SeqProfileRankingStrategy(Enum):
+    QC_RESULT_THEN_SCORE_THEN_CREATED = "QC_RESULT_THEN_SCORE_THEN_CREATED"

--- a/gen_epix/seqdb/domain/model/seq/base.py
+++ b/gen_epix/seqdb/domain/model/seq/base.py
@@ -102,6 +102,18 @@ class QualityMixin:
     def _serialize_qc_result(self, value: enum.QualityControlResult) -> int:
         return value.value
 
+    @staticmethod
+    def get_sort_key(instance: "QualityMixin") -> tuple[int, float]:
+        """
+        Return a sort key for sorting instances of QualityMixin by quality control
+        result and subsequently score. The qc_result is considered leading as it is
+        mandatory, and the qc_score is considered secondary as it is optional and may be
+        less reliable.
+        """
+        return instance.qc_result.get_sort_key(), (
+            instance.qc_score if instance.qc_score is not None else float("-inf")
+        )
+
 
 class BaseSeq(Model):
     """

--- a/gen_epix/seqdb/domain/policy/permission.py
+++ b/gen_epix/seqdb/domain/policy/permission.py
@@ -58,6 +58,8 @@ class RoleGenerator(CommonRoleGenerator):
             (command.ReadSetIdentifierCrudCommand, PermissionTypeSet.CRUD),
             (command.RefSeqCrudCommand, PermissionTypeSet.R),
             (command.CalculatePhylogeneticTreeCommand, PermissionTypeSet.E),
+            (command.RetrieveBestSeqPerSampleCommand, PermissionTypeSet.E),
+            (command.RetrieveBestSeqProfilePerSampleCommand, PermissionTypeSet.E),
             (command.RetrieveSeqDistanceLastModifiedCommand, PermissionTypeSet.E),
             (command.RetrieveSeqFastaCommand, PermissionTypeSet.E),
             (command.RetrieveSimilarProfilesCommand, PermissionTypeSet.E),

--- a/gen_epix/seqdb/domain/service/seq.py
+++ b/gen_epix/seqdb/domain/service/seq.py
@@ -45,6 +45,14 @@ class BaseSeqService(BaseService):
             self.update_seq_distances,
         )
         f(
+            command.RetrieveBestSeqPerSampleCommand,
+            self.retrieve_best_seq_per_sample,
+        )
+        f(
+            command.RetrieveBestSeqProfilePerSampleCommand,
+            self.retrieve_best_seq_profile_per_sample,
+        )
+        f(
             command.ProtocolCrudCommand,
             self.crud_protocol,
         )
@@ -227,6 +235,20 @@ class BaseSeqService(BaseService):
         self,
         cmd: command.UpdateSeqDistancesCommand,
     ) -> list[model.CalculateSeqDistancesResult]:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def retrieve_best_seq_per_sample(
+        self,
+        cmd: command.RetrieveBestSeqPerSampleCommand,
+    ) -> dict[UUID, UUID]:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def retrieve_best_seq_profile_per_sample(
+        self,
+        cmd: command.RetrieveBestSeqProfilePerSampleCommand,
+    ) -> dict[UUID, UUID]:
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/gen_epix/seqdb/repositories/sa_model/seq/base.py
+++ b/gen_epix/seqdb/repositories/sa_model/seq/base.py
@@ -43,11 +43,11 @@ class QualityMixin:
     SQLAlchemy model mixin for adding a number of standard fields.
     """
 
-    qc_score: Mapped[float] = get_mixin_mapped_column(
-        model.QualityMixin, "qc_score", sa.Float
-    )
     qc_result: Mapped[enum.QualityControlResult] = get_mixin_mapped_column(
         model.QualityMixin, "qc_result", sa.String
+    )
+    qc_score: Mapped[float] = get_mixin_mapped_column(
+        model.QualityMixin, "qc_score", sa.Float
     )
     qc_report: Mapped[Json | None] = get_mixin_mapped_column(
         model.QualityMixin, "qc_report", sa.JSON, nullable=True

--- a/gen_epix/seqdb/services/remote_app.py
+++ b/gen_epix/seqdb/services/remote_app.py
@@ -9,6 +9,8 @@ from gen_epix.commondb.services.remote_app import CommondbRemoteApp
 from gen_epix.fastapp.model import Command
 from gen_epix.seqdb.api import (
     CalculatePhylogeneticTreeRequestBody,
+    RetrieveBestSeqPerSampleRequestBody,
+    RetrieveBestSeqProfilePerSampleRequestBody,
     RetrieveSeqFastaRequestBody,
     RetrieveSimilarProfilesRequestBody,
 )
@@ -23,6 +25,8 @@ class SeqdbRemoteApp(CommondbRemoteApp):
 
     ROUTE_MAP: dict[type[Command], str] = {
         command.CalculatePhylogeneticTreeCommand: "/calculate/phylogenetic_tree",
+        command.RetrieveBestSeqPerSampleCommand: "/retrieve/best_seq_per_sample",
+        command.RetrieveBestSeqProfilePerSampleCommand: "/retrieve/best_seq_profile_per_sample",
         command.RetrieveSeqFastaCommand: "/retrieve/seq_fasta",
         command.CreateFileCommand: "/create/file",
         command.RetrieveSimilarProfilesCommand: "/retrieve/similar_profiles",
@@ -77,6 +81,22 @@ class SeqdbRemoteApp(CommondbRemoteApp):
         self.register_handler(
             command.UploadSamplesCommand,
             self.upload_samples,
+        )
+        self.register_route(
+            command.RetrieveBestSeqPerSampleCommand,
+            self.ROUTE_MAP[command.RetrieveBestSeqPerSampleCommand],
+        )
+        self.register_route(
+            command.RetrieveBestSeqProfilePerSampleCommand,
+            self.ROUTE_MAP[command.RetrieveBestSeqProfilePerSampleCommand],
+        )
+        self.register_handler(
+            command.RetrieveBestSeqPerSampleCommand,
+            self.retrieve_best_seq_per_sample,
+        )
+        self.register_handler(
+            command.RetrieveBestSeqProfilePerSampleCommand,
+            self.retrieve_best_seq_profile_per_sample,
         )
 
     def calculate_phylogenetic_tree(
@@ -197,3 +217,47 @@ class SeqdbRemoteApp(CommondbRemoteApp):
             response.raise_for_status()
             data = response.json()
         return model.SampleBatchUploadResult(**data)
+
+    def retrieve_best_seq_per_sample(
+        self,
+        cmd: command.RetrieveBestSeqPerSampleCommand,
+    ) -> dict[UUID, UUID]:
+        headers = self.get_headers(cmd)
+        route = self.get_route(cmd)
+
+        request_body = RetrieveBestSeqPerSampleRequestBody(
+            protocol_ids=cmd.protocol_ids,
+            sample_ids=cmd.sample_ids,
+        )
+
+        with self.get_client(cmd) as client:
+            response = client.post(
+                route,
+                json=json.loads(request_body.model_dump_json()),
+                headers=headers,
+            )
+            response.raise_for_status()
+            data = response.json()
+        return {UUID(k): UUID(v) for k, v in data.items()}
+
+    def retrieve_best_seq_profile_per_sample(
+        self,
+        cmd: command.RetrieveBestSeqProfilePerSampleCommand,
+    ) -> dict[UUID, UUID]:
+        headers = self.get_headers(cmd)
+        route = self.get_route(cmd)
+
+        request_body = RetrieveBestSeqProfilePerSampleRequestBody(
+            protocol_ids=cmd.protocol_ids,
+            sample_ids=cmd.sample_ids,
+        )
+
+        with self.get_client(cmd) as client:
+            response = client.post(
+                route,
+                json=json.loads(request_body.model_dump_json()),
+                headers=headers,
+            )
+            response.raise_for_status()
+            data = response.json()
+        return {UUID(k): UUID(v) for k, v in data.items()}

--- a/gen_epix/seqdb/services/remote_app.py
+++ b/gen_epix/seqdb/services/remote_app.py
@@ -77,14 +77,6 @@ class SeqdbRemoteApp(CommondbRemoteApp):
             command.UploadSamplesCommand,
             self.upload_samples,
         )
-        self.register_route(
-            command.RetrieveBestSeqPerSampleCommand,
-            self.ROUTE_MAP[command.RetrieveBestSeqPerSampleCommand],
-        )
-        self.register_route(
-            command.RetrieveBestSeqProfilePerSampleCommand,
-            self.ROUTE_MAP[command.RetrieveBestSeqProfilePerSampleCommand],
-        )
         self.register_handler(
             command.RetrieveBestSeqPerSampleCommand,
             self.retrieve_best_seq_per_sample,

--- a/gen_epix/seqdb/services/remote_app.py
+++ b/gen_epix/seqdb/services/remote_app.py
@@ -27,36 +27,31 @@ class SeqdbRemoteApp(CommondbRemoteApp):
         command.CreateFileCommand: "/create/file",
         command.RetrieveSimilarProfilesCommand: "/retrieve/similar_profiles",
         command.UploadSamplesCommand: "/upload/samples",
+        command.RetrieveBestSeqPerSampleCommand: "/retrieve/best_seq_per_sample",
+        command.RetrieveBestSeqProfilePerSampleCommand: "/retrieve/best_seq_profile_per_sample",
     }
 
     DEFAULT_HTTP_TIMEOUTS: dict[type[Command], float] = {
         command.UploadSamplesCommand: 45.0,
         command.RetrieveSamplesByIdCommand: 45.0,
         command.RetrieveSamplesByQueryCommand: 45.0,
+        command.RetrieveBestSeqPerSampleCommand: 15.0,
+        command.RetrieveBestSeqProfilePerSampleCommand: 15.0,
     }
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(DOMAIN, *args, **kwargs)
-        # Register routes and handlers
-        self.register_route(
-            command.CalculatePhylogeneticTreeCommand,
-            self.ROUTE_MAP[command.CalculatePhylogeneticTreeCommand],
+        # Register routes
+        for cmd_class, route in self.ROUTE_MAP.items():
+            self.register_route(cmd_class, route)
+        # Register handlers
+        self.register_handler(
+            command.RetrieveBestSeqPerSampleCommand,
+            self.retrieve_best_seq_per_sample,
         )
-        self.register_route(
-            command.RetrieveSeqFastaCommand,
-            self.ROUTE_MAP[command.RetrieveSeqFastaCommand],
-        )
-        self.register_route(
-            command.CreateFileCommand,
-            self.ROUTE_MAP[command.CreateFileCommand],
-        )
-        self.register_route(
-            command.RetrieveSimilarProfilesCommand,
-            self.ROUTE_MAP[command.RetrieveSimilarProfilesCommand],
-        )
-        self.register_route(
-            command.UploadSamplesCommand,
-            self.ROUTE_MAP[command.UploadSamplesCommand],
+        self.register_handler(
+            command.RetrieveBestSeqProfilePerSampleCommand,
+            self.retrieve_best_seq_profile_per_sample,
         )
         self.register_handler(
             command.CalculatePhylogeneticTreeCommand,
@@ -197,3 +192,39 @@ class SeqdbRemoteApp(CommondbRemoteApp):
             response.raise_for_status()
             data = response.json()
         return model.SampleBatchUploadResult(**data)
+
+    def retrieve_best_seq_per_sample(
+        self,
+        cmd: command.RetrieveBestSeqPerSampleCommand,
+    ) -> dict[UUID, UUID]:
+        headers = self.get_headers(cmd)
+        route = self.get_route(cmd)
+        request_body = cmd
+        with self.get_client(cmd) as client:
+            response = client.post(
+                route,
+                json=json.loads(request_body.model_dump_json()),
+                headers=headers,
+            )
+            response.raise_for_status()
+            data = response.json()
+        return {UUID(sample_id): UUID(seq_id) for sample_id, seq_id in data.items()}
+
+    def retrieve_best_seq_profile_per_sample(
+        self,
+        cmd: command.RetrieveBestSeqProfilePerSampleCommand,
+    ) -> dict[UUID, UUID]:
+        headers = self.get_headers(cmd)
+        route = self.get_route(cmd)
+        request_body = cmd
+        with self.get_client(cmd) as client:
+            response = client.post(
+                route,
+                json=json.loads(request_body.model_dump_json()),
+                headers=headers,
+            )
+            response.raise_for_status()
+            data = response.json()
+        return {
+            UUID(sample_id): UUID(profile_id) for sample_id, profile_id in data.items()
+        }

--- a/gen_epix/seqdb/services/seq/retrieve_best.py
+++ b/gen_epix/seqdb/services/seq/retrieve_best.py
@@ -42,6 +42,11 @@ def _get_best_id_per_sample(
     Retrieve the best Seq or SeqProfile ID per sample for the given protocol and sample
     IDs, based on the specified ranking strategy.
     """
+    model_class = (
+        model.SeqProfile
+        if isinstance(cmd, command.RetrieveBestSeqProfilePerSampleCommand)
+        else model.Seq
+    )
     user_id = cmd.user.id if cmd.user else None
     if cmd.ranking_strategy not in {
         enum.SeqProfileRankingStrategy.QC_RESULT_THEN_SCORE_THEN_CREATED,
@@ -72,7 +77,7 @@ def _get_best_id_per_sample(
         iter_fields = repository.read_fields(
             uow,
             user_id,
-            model.SeqProfile,
+            model_class,
             field_names=["id", "sample_id", "qc_result", "qc_score", "created_at"],
             filter=filter,
         )
@@ -88,11 +93,11 @@ def _get_best_id_per_sample(
             }
             sort_fn = lambda x: (x[1], map_qc_result_to_sort_key[x[2]], x[3], x[4])
             sorted_iter = sorted(iter_fields, key=sort_fn)
-            sample_id = None
-            for profile_id, sample_id, qc_result, qc_score, created_at in sorted_iter:
-                if sample_id != sample_id:
-                    best_id_per_sample[sample_id] = profile_id
-                    sample_id = sample_id
+            prev_sample_id = None
+            for entry_id, sample_id, qc_result, qc_score, created_at in sorted_iter:
+                if sample_id != prev_sample_id:
+                    best_id_per_sample[sample_id] = entry_id
+                    prev_sample_id = sample_id
         else:
             raise AssertionError(
                 "Should not reach here due to earlier check on ranking strategy"

--- a/gen_epix/seqdb/services/seq/retrieve_best.py
+++ b/gen_epix/seqdb/services/seq/retrieve_best.py
@@ -56,10 +56,10 @@ def _get_best_id_per_sample(
             "a3f7c2b1", f"Unsupported ranking strategy: {cmd.ranking_strategy}"
         )
 
-    protocol_ids = cmd.protocol_ids or set()
     sample_ids = cmd.sample_ids or set()
-    if not protocol_ids or not sample_ids:
+    if not sample_ids:
         return {}
+    protocol_ids = cmd.protocol_ids or set()
 
     repository: BaseSeqRepository = self.repository  # type: ignore[assignment]
     sample_filter = UuidSetFilter(key="sample_id", members=frozenset(sample_ids))

--- a/gen_epix/seqdb/services/seq/retrieve_best.py
+++ b/gen_epix/seqdb/services/seq/retrieve_best.py
@@ -1,0 +1,100 @@
+from uuid import UUID
+
+import gen_epix.seqdb.domain.command as command
+import gen_epix.seqdb.domain.model as model
+from gen_epix.filter.base import Filter
+from gen_epix.filter.composite import CompositeFilter
+from gen_epix.filter.enum import LogicalOperator
+from gen_epix.filter.uuid_set import UuidSetFilter
+from gen_epix.seqdb.domain import enum, exc
+from gen_epix.seqdb.domain.repository import BaseSeqRepository
+from gen_epix.seqdb.domain.service import BaseSeqService
+
+
+def seq_service_retrieve_best_seq_profile_per_sample(
+    self: BaseSeqService,
+    cmd: command.RetrieveBestSeqProfilePerSampleCommand,
+) -> dict[UUID, UUID]:
+    """
+    Retrieve the best SeqProfile ID per sample for the given protocol and sample IDs.
+    """
+    return _get_best_id_per_sample(self, cmd)
+
+
+def seq_service_retrieve_best_seq_per_sample(
+    self: BaseSeqService,
+    cmd: command.RetrieveBestSeqPerSampleCommand,
+) -> dict[UUID, UUID]:
+    """
+    Retrieve the best Seq ID per sample for the given protocol and sample IDs.
+    """
+    return _get_best_id_per_sample(self, cmd)
+
+
+def _get_best_id_per_sample(
+    self: BaseSeqService,
+    cmd: (
+        command.RetrieveBestSeqPerSampleCommand
+        | command.RetrieveBestSeqProfilePerSampleCommand
+    ),
+) -> dict[UUID, UUID]:
+    """
+    Retrieve the best Seq or SeqProfile ID per sample for the given protocol and sample
+    IDs, based on the specified ranking strategy.
+    """
+    user_id = cmd.user.id if cmd.user else None
+    if cmd.ranking_strategy not in {
+        enum.SeqProfileRankingStrategy.QC_RESULT_THEN_SCORE_THEN_CREATED,
+        enum.SeqRankingStrategy.QC_RESULT_THEN_SCORE_THEN_CREATED,
+    }:
+        raise exc.ServiceException(
+            "a3f7c2b1", f"Unsupported ranking strategy: {cmd.ranking_strategy}"
+        )
+
+    protocol_ids = cmd.protocol_ids or set()
+    sample_ids = cmd.sample_ids or set()
+    if not protocol_ids or not sample_ids:
+        return {}
+
+    repository: BaseSeqRepository = self.repository  # type: ignore[assignment]
+    sample_filter = UuidSetFilter(key="sample_id", members=frozenset(sample_ids))
+    filter: Filter
+    if protocol_ids:
+        protocol_filter = UuidSetFilter(
+            key="protocol_id", members=frozenset(protocol_ids)
+        )
+        filter = CompositeFilter(
+            filters=[sample_filter, protocol_filter], operator=LogicalOperator.AND
+        )
+    else:
+        filter = sample_filter
+    with repository.uow() as uow:
+        iter_fields = repository.read_fields(
+            uow,
+            user_id,
+            model.SeqProfile,
+            field_names=["id", "sample_id", "qc_result", "qc_score", "created_at"],
+            filter=filter,
+        )
+        best_id_per_sample: dict[UUID, UUID] = {}
+        if cmd.ranking_strategy in {
+            enum.SeqProfileRankingStrategy.QC_RESULT_THEN_SCORE_THEN_CREATED,
+            enum.SeqRankingStrategy.QC_RESULT_THEN_SCORE_THEN_CREATED,
+        }:
+            # Sort by (sample_id, qc_result, qc_score, created_at)
+            map_qc_result_to_sort_key = {
+                x: enum.QualityControlResult.get_sort_key(x)
+                for x in enum.QualityControlResult
+            }
+            sort_fn = lambda x: (x[1], map_qc_result_to_sort_key[x[2]], x[3], x[4])
+            sorted_iter = sorted(iter_fields, key=sort_fn)
+            sample_id = None
+            for profile_id, sample_id, qc_result, qc_score, created_at in sorted_iter:
+                if sample_id != sample_id:
+                    best_id_per_sample[sample_id] = profile_id
+                    sample_id = sample_id
+        else:
+            raise AssertionError(
+                "Should not reach here due to earlier check on ranking strategy"
+            )
+    return best_id_per_sample

--- a/gen_epix/seqdb/services/seq/service.py
+++ b/gen_epix/seqdb/services/seq/service.py
@@ -76,6 +76,10 @@ from gen_epix.seqdb.services.seq.crud_tree_algorithm import (
 from gen_epix.seqdb.services.seq.crud_tree_algorithm_class import (
     seq_service_crud_tree_algorithm_class,
 )
+from gen_epix.seqdb.services.seq.retrieve_best import (
+    seq_service_retrieve_best_seq_per_sample,
+    seq_service_retrieve_best_seq_profile_per_sample,
+)
 from gen_epix.seqdb.services.seq.retrieve_sample import (
     seq_service_retrieve_samples_by_id,
     seq_service_retrieve_samples_by_query,
@@ -157,6 +161,18 @@ class SeqService(BaseSeqService):
         cmd: command.UpdateSeqDistancesCommand,
     ) -> list[model.CalculateSeqDistancesResult]:
         return seq_service_update_seq_distances(self, cmd)
+
+    def retrieve_best_seq_per_sample(
+        self,
+        cmd: command.RetrieveBestSeqPerSampleCommand,
+    ) -> dict[UUID, UUID]:
+        return seq_service_retrieve_best_seq_per_sample(self, cmd)
+
+    def retrieve_best_seq_profile_per_sample(
+        self,
+        cmd: command.RetrieveBestSeqProfilePerSampleCommand,
+    ) -> dict[UUID, UUID]:
+        return seq_service_retrieve_best_seq_profile_per_sample(self, cmd)
 
     def crud_protocol(
         self,


### PR DESCRIPTION
## Merge https://github.com/RIVM-bioinformatics/gen-epix-api/pull/506 first!
also already pulled in https://github.com/RIVM-bioinformatics/gen-epix-api/pull/509 into this branch

## Summary
Fixes to the seqdb-to-casedb orchestration flow to make RetrieveBestSeq(Profile)PerSample work end-to-end after merging the salmonella branch.

## Changes
seqdb: Add best_seq_per_sample methods to service layer
seqdb: Add RetrieveBestSeq{,Profile}PerSample handlers to SeqdbRemoteApp
seqdb: Fix retrieve_best — treat protocol_ids=None as "no filter" instead of short-circuiting to empty result
casedb: Fix case content merge on update — look up existing content by case ID (Row tuples, not plain dicts)
fix: Overwrite-in-loop bug that caused always-empty return value
fix: Return value now serialized as dict as required by casebuilder
fix: Rate limiting can be disabled via RATELIMIT_ENABLED env var