### PR TITLE
fix: warning that was annoying me

### DIFF
--- a/gen_epix/fastapp/service.py
+++ b/gen_epix/fastapp/service.py
@@ -558,7 +558,7 @@ class BaseService[Repository: BaseRepository = BaseRepository](abc.ABC):
                     )
 
     def __del__(self) -> None:
-        if self._setup_logger:
+        if getattr(self, "_setup_logger", None):
             self._setup_logger.info(
                 self.create_log_message("d84f9d21", "STOPPING_SERVICE")
             )


### PR DESCRIPTION
__del__ now uses getattr(self, "_setup_logger", None) to safely handle objects whose __init__ was bypassed