### PR TITLE
Issues encountered when trying to run ETL jobs

### DIFF
--- a/gen_epix/filter/string_set.py
+++ b/gen_epix/filter/string_set.py
@@ -1,9 +1,14 @@
+import enum as _stdlib_enum
 from typing import Any, Literal, Self
 
 from pydantic import Field, PrivateAttr, model_validator
 
 from gen_epix.filter.base import Filter
 from gen_epix.filter.enum import FilterType
+
+
+def _enum_to_str(x: Any) -> str:
+    return x.name if isinstance(x, _stdlib_enum.Enum) else x
 
 
 class StringSetFilter(Filter):
@@ -24,9 +29,9 @@ class StringSetFilter(Filter):
         # Generate the function to check if a value is in the set of terms
         # The function is generated instead of defined to be able to optimize the check
         if self.case_sensitive:
-            self._match = lambda x: x in self._members  # type: ignore
+            self._match = lambda x: _enum_to_str(x) in self._members  # type: ignore
         else:
-            self._match = lambda x: x.lower() in self._members  # type: ignore
+            self._match = lambda x: _enum_to_str(x).lower() in self._members  # type: ignore
         return self
 
     def _match(self, value: Any) -> bool:

--- a/gen_epix/omopdb/services/remote_app.py
+++ b/gen_epix/omopdb/services/remote_app.py
@@ -14,6 +14,8 @@ class OmopdbRemoteApp(CommondbRemoteApp):
 
     ROUTE_MAP: dict[type[Command], str] = {
         command.UploadPersonsCommand: "/upload/persons",
+        command.RetrievePersonsByQueryCommand: "/retrieve/person_ids_by_query",
+        command.RetrievePersonsByIdCommand: "/retrieve/persons_by_ids",
     }
 
     DEFAULT_HTTP_TIMEOUTS: dict[type[Command], float] = {
@@ -32,6 +34,14 @@ class OmopdbRemoteApp(CommondbRemoteApp):
         self.register_handler(
             command.UploadPersonsCommand,
             self.upload_persons,
+        )
+        self.register_handler(
+            command.RetrievePersonsByQueryCommand,
+            self.retrieve_persons_by_query,
+        )
+        self.register_handler(
+            command.RetrievePersonsByIdCommand,
+            self.retrieve_persons_by_id,
         )
 
     def upload_persons(
@@ -52,3 +62,39 @@ class OmopdbRemoteApp(CommondbRemoteApp):
             response.raise_for_status()
             data = response.json()
         return model.PersonBatchUploadResult(**data)
+
+    def retrieve_persons_by_query(
+        self,
+        cmd: command.RetrievePersonsByQueryCommand,
+    ) -> model.PersonQueryResult:
+        headers = self.get_headers(cmd)
+        route = self.get_route(cmd)
+        request_body = cmd.person_query
+
+        with self.get_client(cmd) as client:
+            response = client.post(
+                route,
+                json=json.loads(request_body.model_dump_json()),
+                headers=headers,
+            )
+            response.raise_for_status()
+            data = response.json()
+        return model.PersonQueryResult(**data)
+
+    def retrieve_persons_by_id(
+        self,
+        cmd: command.RetrievePersonsByIdCommand,
+    ) -> list[model.FullPerson]:
+        headers = self.get_headers(cmd)
+        route = self.get_route(cmd)
+        request_body = cmd
+
+        with self.get_client(cmd) as client:
+            response = client.post(
+                route,
+                json=json.loads(request_body.model_dump_json()),
+                headers=headers,
+            )
+            response.raise_for_status()
+            data = response.json()
+        return [model.FullPerson(**person) for person in data]

--- a/test/filter/unit/test_filter_match.py
+++ b/test/filter/unit/test_filter_match.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+from enum import IntEnum
 from test.filter.unit import util
 
 import numpy as np
@@ -65,6 +66,27 @@ class TestFilterMatch:
             util.validate_filter_behavior(
                 filter, rows, [True, True, False, False, False]
             )
+
+    def test_string_set_match_with_enum(self) -> None:
+        class Color(IntEnum):
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+
+        # case_sensitive=True: enum .name must be in members
+        f = StringSetFilter(key="a", members=frozenset({"RED", "GREEN"}), case_sensitive=True)
+        rows = [{"a": x} for x in [Color.RED, Color.GREEN, Color.BLUE, None]]
+        util.validate_filter_behavior(f, rows, [True, True, False, False])
+
+        # case_sensitive=False: .name compared case-insensitively
+        f = StringSetFilter(key="a", members=frozenset({"red"}), case_sensitive=False)
+        rows = [{"a": x} for x in [Color.RED, Color.GREEN, "RED", None]]
+        util.validate_filter_behavior(f, rows, [True, False, True, False])
+
+        # plain strings still work unchanged
+        f = StringSetFilter(key="a", members=frozenset({"x"}), case_sensitive=True)
+        rows = [{"a": x} for x in ["x", "y", None]]
+        util.validate_filter_behavior(f, rows, [True, False, False])
 
     def test_number_range_match(self) -> None:
         fixed_args = {

--- a/test/omopdb/unit/services/test_remote_app.py
+++ b/test/omopdb/unit/services/test_remote_app.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import UUID
+from unittest.mock import MagicMock, Mock, patch
+
+from gen_epix.fastapp.enum import AuthProtocol
+from gen_epix.omopdb.domain import command, model
+from gen_epix.omopdb.services.remote_app import OmopdbRemoteApp
+
+
+def _fake_app_init(self: object, domain: object, **kwargs: object) -> None:
+    setattr(self, "_domain", domain)
+    setattr(self, "_logger", None)
+    setattr(self, "_command_handler_map", {})
+    setattr(self, "_command_listeners", {})
+    setattr(self, "_command_stack", [])
+
+
+def _make_app() -> OmopdbRemoteApp:
+    domain = SimpleNamespace(crud_commands=[])
+    with patch("gen_epix.omopdb.services.remote_app.DOMAIN", domain), patch(
+        "gen_epix.fastapp.remote_app.App.__init__", _fake_app_init
+    ):
+        return OmopdbRemoteApp(
+            host="example.org",
+            port=8000,
+            auth_protocol=AuthProtocol.NONE,
+        )
+
+
+def test_registers_person_retrieval_routes_and_handlers() -> None:
+    app = _make_app()
+
+    query_cmd = command.RetrievePersonsByQueryCommand(
+        person_query=model.PersonQuery(
+            modified_since=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+    )
+    ids_cmd = command.RetrievePersonsByIdCommand(
+        person_ids=[UUID("11111111-1111-1111-1111-111111111111")]
+    )
+
+    assert app.get_route(query_cmd).endswith("/retrieve/person_ids_by_query")
+    assert app.get_route(ids_cmd).endswith("/retrieve/persons_by_ids")
+    assert app.get_handler(type(query_cmd)).__func__ is OmopdbRemoteApp.retrieve_persons_by_query
+    assert app.get_handler(type(ids_cmd)).__func__ is OmopdbRemoteApp.retrieve_persons_by_id
+
+
+def test_retrieve_persons_by_query_posts_query_body() -> None:
+    app = _make_app()
+    query = model.PersonQuery(
+        modified_since=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    cmd = command.RetrievePersonsByQueryCommand(person_query=query)
+    response_payload = {
+        "person_query": query.model_dump(mode="json"),
+        "person_ids": ["11111111-1111-1111-1111-111111111111"],
+        "is_max_results_exceeded": False,
+    }
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = response_payload
+    client = Mock()
+    client.post.return_value = response
+    client_context = MagicMock()
+    client_context.__enter__.return_value = client
+    client_context.__exit__.return_value = None
+
+    with patch.object(app, "get_client", return_value=client_context), patch.object(
+        app, "get_headers", return_value={"X-Test": "1"}
+    ):
+        result = app.retrieve_persons_by_query(cmd)
+
+    assert result.person_ids == [UUID("11111111-1111-1111-1111-111111111111")]
+    client.post.assert_called_once()
+    posted_route = client.post.call_args.args[0]
+    posted_json = client.post.call_args.kwargs["json"]
+    assert posted_route.endswith("/retrieve/person_ids_by_query")
+    assert posted_json == query.model_dump(mode="json")


### PR DESCRIPTION
companion to a branch with the same name in idsdb, but also contains fixes needed for lsp-data branch LSP-3301

fix: match enums to strings in filter using their .name
feat: register omopdb remote app handlers needed for making cohorts and cases in lsp-data