### PR TITLE
Lsp 3360 implement exists crud operations

### DIFF
--- a/gen_epix/fastapp/remote_app.py
+++ b/gen_epix/fastapp/remote_app.py
@@ -401,6 +401,113 @@ class RemoteApp(App):
         retval = self._content_to_obj(response, return_model_class, is_list=is_list)
         return retval
 
+    def _exists_some_via_query_ids(
+        self,
+        base_route: str,
+        query_route_suffix: str,
+        ids_route_suffix: str,
+        model_class: type[model.Model],
+        obj_ids: list[Any],
+        client: httpx.Client,
+        headers: dict[str, str],
+    ) -> list[bool]:
+        if not obj_ids:
+            return []
+
+        id_field_name = model_class.ENTITY.id_field_name
+        if not isinstance(id_field_name, str):
+            raise AssertionError(
+                f"Model {model_class.__name__} does not define a string id_field_name."
+            )
+        query_suffix = query_route_suffix.rstrip("/")
+        ids_suffix = (
+            ids_route_suffix
+            if ids_route_suffix.startswith("/")
+            else ("/" + ids_route_suffix)
+        )
+        query_ids_url = base_route + query_suffix + ids_suffix
+
+        id_type = self._classify_exists_id_type(obj_ids)
+        number_id_types = {"int", "float", "decimal"}
+
+        if id_type == "uuid":
+            query_filter = TypedUuidSetFilter(
+                type=FilterType.UUID_SET.value,
+                key=id_field_name,
+                members=frozenset(obj_ids),
+            )
+        elif id_type == "string":
+            query_filter = TypedStringSetFilter(
+                type=FilterType.STRING_SET.value,
+                key=id_field_name,
+                members=frozenset(obj_ids),
+                case_sensitive=True,
+            )
+        elif id_type in number_id_types:
+            query_filter = TypedNumberSetFilter(
+                type=FilterType.NUMBER_SET.value,
+                key=id_field_name,
+                members=frozenset(obj_ids),
+            )
+        else:
+            return self._exists_some_via_get(
+                base_route=base_route,
+                obj_ids=obj_ids,
+                client=client,
+                headers=headers,
+            )
+
+        response = client.post(
+            query_ids_url,
+            json=json.loads(query_filter.model_dump_json()),
+            headers=headers,
+        )
+        response.raise_for_status()
+        found_ids = json.loads(response.content.decode(response.encoding or "utf-8"))
+        if id_type == "uuid":
+            found_set = {UUID(x) for x in found_ids}
+        else:
+            found_set = set(found_ids)
+        return [obj_id in found_set for obj_id in obj_ids]
+
+    @staticmethod
+    def _classify_exists_id_type(obj_ids: list[Any]) -> str:
+        if not obj_ids:
+            return "mixed"
+
+        first_type = type(obj_ids[0])
+        if not all(type(obj_id) is first_type for obj_id in obj_ids[1:]):
+            return "mixed"
+
+        type_to_id_kind: dict[type, str] = {
+            UUID: "uuid",
+            str: "string",
+            int: "int",
+            float: "float",
+            Decimal: "decimal",
+        }
+        return type_to_id_kind.get(first_type, "mixed")
+
+    @staticmethod
+    def _exists_some_via_get(
+        base_route: str,
+        obj_ids: list[Any],
+        client: httpx.Client,
+        headers: dict[str, str],
+    ) -> list[bool]:
+        is_existing: list[bool] = []
+        for obj_id in obj_ids:
+            response = client.get(
+                f"{base_route}/{obj_id}",
+                headers=headers,
+            )
+            if response.status_code == 404:
+                is_existing.append(False)
+                continue
+            response.raise_for_status()
+            is_existing.append(True)
+        return is_existing
+
     @staticmethod
     def _content_to_obj(
         response: httpx.Response, retval_class: type, is_list: bool = False

--- a/gen_epix/fastapp/remote_app.py
+++ b/gen_epix/fastapp/remote_app.py
@@ -1,6 +1,7 @@
 import json
 import ssl
 from collections.abc import Callable
+from decimal import Decimal
 from functools import partial
 from pathlib import Path
 from typing import Any, cast
@@ -15,6 +16,12 @@ from gen_epix.fastapp.app import App
 from gen_epix.fastapp.domain.domain import Domain
 from gen_epix.fastapp.enum import CrudOperation, EventTiming, HttpProtocol, StringCasing
 from gen_epix.fastapp.exc import ServiceException
+from gen_epix.filter import (
+    FilterType,
+    TypedNumberSetFilter,
+    TypedStringSetFilter,
+    TypedUuidSetFilter,
+)
 from gen_epix.fastapp.model import Command, CrudCommand, Policy
 from gen_epix.fastapp.util import create_ssl_context
 
@@ -319,6 +326,28 @@ class RemoteApp(App):
                     response = client.get(
                         f"{base_route}/{cmd.obj_ids}",
                         headers=headers,
+                    )
+                case CrudOperation.EXISTS_ONE:
+                    assert cmd.obj_ids is not None
+                    return self._exists_some_via_query_ids(
+                        client=client,
+                        headers=headers,
+                        model_class=model_class,
+                        base_route=base_route,
+                        query_route_suffix=query_route_suffix,
+                        ids_route_suffix=ids_route_suffix,
+                        obj_ids=[cmd.obj_ids],
+                    )[0]
+                case CrudOperation.EXISTS_SOME:
+                    assert isinstance(cmd.obj_ids, list)
+                    return self._exists_some_via_query_ids(
+                        client=client,
+                        headers=headers,
+                        model_class=model_class,
+                        base_route=base_route,
+                        query_route_suffix=query_route_suffix,
+                        ids_route_suffix=ids_route_suffix,
+                        obj_ids=cmd.obj_ids,
                     )
                 case CrudOperation.CREATE_ONE:
                     assert isinstance(cmd.objs, model.Model)

--- a/gen_epix/fastapp/remote_app.py
+++ b/gen_epix/fastapp/remote_app.py
@@ -16,14 +16,14 @@ from gen_epix.fastapp.app import App
 from gen_epix.fastapp.domain.domain import Domain
 from gen_epix.fastapp.enum import CrudOperation, EventTiming, HttpProtocol, StringCasing
 from gen_epix.fastapp.exc import ServiceException
+from gen_epix.fastapp.model import Command, CrudCommand, Policy
+from gen_epix.fastapp.util import create_ssl_context
 from gen_epix.filter import (
     FilterType,
     TypedNumberSetFilter,
     TypedStringSetFilter,
     TypedUuidSetFilter,
 )
-from gen_epix.fastapp.model import Command, CrudCommand, Policy
-from gen_epix.fastapp.util import create_ssl_context
 
 
 class RemoteApp(App):
@@ -429,6 +429,7 @@ class RemoteApp(App):
 
         id_type = self._classify_exists_id_type(obj_ids)
         number_id_types = {"int", "float", "decimal"}
+        query_filter: TypedUuidSetFilter | TypedStringSetFilter | TypedNumberSetFilter
 
         if id_type == "uuid":
             query_filter = TypedUuidSetFilter(

--- a/test/fastapp/unit/test_app_log_summarise.py
+++ b/test/fastapp/unit/test_app_log_summarise.py
@@ -152,7 +152,8 @@ def test_create_log_message_uses_configured_threshold_and_sample_size() -> None:
 @pytest.mark.scenario_ids("TC-LOG-01-01")
 def test_large_dict_is_summarised() -> None:
     """Dicts with more than DEFAULT_LOG_MAX_DICT_ITEMS entries (e.g. locus_allele_id_map)
-    are replaced with a _count/_sample summary, even when individual values are short."""
+    are replaced with a _count/_sample summary, even when individual values are short.
+    """
     app = App(logger=None, log_item_class=LogItem)
     large_map = {f"LOCUS_{i:04d}": str(uuid.uuid4()) for i in range(500)}
     result = app._summarise_command_object_for_log({"locus_allele_id_map": large_map})
@@ -167,7 +168,9 @@ def test_large_dict_is_summarised() -> None:
 def test_small_dict_passes_through() -> None:
     """Dicts at or below DEFAULT_LOG_MAX_DICT_ITEMS entries are not modified."""
     app = App(logger=None, log_item_class=LogItem)
-    small_map = {f"k{i}": str(uuid.uuid4()) for i in range(App.DEFAULT_LOG_MAX_DICT_ITEMS)}
+    small_map = {
+        f"k{i}": str(uuid.uuid4()) for i in range(App.DEFAULT_LOG_MAX_DICT_ITEMS)
+    }
     result = app._summarise_command_object_for_log({"mapping": small_map})
     assert result["mapping"] == small_map
 

--- a/test/fastapp/unit/test_remote_app.py
+++ b/test/fastapp/unit/test_remote_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from typing import Any, Callable, ClassVar, cast
 from unittest import TestCase
 from unittest.mock import Mock, patch
@@ -632,6 +633,62 @@ class TestGeneratedCrudRoutes(BaseRemoteAppTestCase):
             cmd = DummyCrud(operation=CrudOperation.READ_ONE, obj_ids=uuid4())
             retval = handler(cmd)
             self.assertIsNone(retval)
+
+    def test_create_generated_crud_handler_exists_operations(self) -> None:
+        # Create input
+        base_route = "http://example.org:8000/dummy_models"
+        handler = self.app.create_generated_crud_route_handler(DummyCrud, base_route)
+        obj_ids = [uuid4(), uuid4(), uuid4()]
+
+        # Set up mocks
+        with patch("gen_epix.fastapp.remote_app.httpx.Client", FakeClient):
+            # EXISTS_SOME
+            set_fake_response(payload=[str(obj_ids[0]), str(obj_ids[2])], status_code=200)
+            cmd = DummyCrud(operation=CrudOperation.EXISTS_SOME, obj_ids=obj_ids)
+            retval = handler(cmd)
+
+            # Verify
+            self.assertEqual(retval, [True, False, True])
+            self.assertEqual(FakeClient.last_request["method"], "POST")  # type: ignore[index]
+            self.assertTrue(FakeClient.last_request["url"].endswith("/query/ids"))  # type: ignore[index]
+            self.assertEqual(FakeClient.last_request["json"]["type"], "UUID_SET")  # type: ignore[index]
+            self.assertEqual(FakeClient.last_request["json"]["key"], "id")  # type: ignore[index]
+
+            # EXISTS_ONE
+            set_fake_response(payload=[str(obj_ids[1])], status_code=200)
+            cmd = DummyCrud(operation=CrudOperation.EXISTS_ONE, obj_ids=obj_ids[1])
+            retval = handler(cmd)
+            self.assertTrue(retval)
+
+    def test_exists_some_falls_back_to_get_for_mixed_id_types(self) -> None:
+        # Create input
+        base_route = "http://example.org:8000/dummy_models"
+        handler = self.app.create_generated_crud_route_handler(DummyCrud, base_route)
+        cmd = DummyCrud.model_construct(
+            operation=CrudOperation.EXISTS_SOME,
+            obj_ids=[uuid4(), "legacy-id"],
+            objs=None,
+            query_filter=None,
+            props={},
+        )
+
+        # Set up mocks
+        with patch("gen_epix.fastapp.remote_app.httpx.Client", FakeClient):
+            set_fake_response(payload={"id": "anything"}, status_code=200)
+            retval = handler(cmd)
+
+        # Verify
+        self.assertEqual(retval, [True, True])
+        self.assertEqual(FakeClient.last_request["method"], "GET")  # type: ignore[index]
+        self.assertTrue(FakeClient.last_request["url"].endswith("/legacy-id"))  # type: ignore[index]
+
+    def test_classify_exists_id_type(self) -> None:
+        self.assertEqual(RemoteApp._classify_exists_id_type([uuid4()]), "uuid")
+        self.assertEqual(RemoteApp._classify_exists_id_type(["x"]), "string")
+        self.assertEqual(RemoteApp._classify_exists_id_type([1]), "int")
+        self.assertEqual(RemoteApp._classify_exists_id_type([1.1]), "float")
+        self.assertEqual(RemoteApp._classify_exists_id_type([Decimal("1.1")]), "decimal")
+        self.assertEqual(RemoteApp._classify_exists_id_type([1, 2.0]), "mixed")
 
     def test_generated_handler_unsupported_return_type_raises(self) -> None:
         # Create input

--- a/test/fastapp/unit/test_remote_app.py
+++ b/test/fastapp/unit/test_remote_app.py
@@ -643,7 +643,9 @@ class TestGeneratedCrudRoutes(BaseRemoteAppTestCase):
         # Set up mocks
         with patch("gen_epix.fastapp.remote_app.httpx.Client", FakeClient):
             # EXISTS_SOME
-            set_fake_response(payload=[str(obj_ids[0]), str(obj_ids[2])], status_code=200)
+            set_fake_response(
+                payload=[str(obj_ids[0]), str(obj_ids[2])], status_code=200
+            )
             cmd = DummyCrud(operation=CrudOperation.EXISTS_SOME, obj_ids=obj_ids)
             retval = handler(cmd)
 
@@ -687,7 +689,9 @@ class TestGeneratedCrudRoutes(BaseRemoteAppTestCase):
         self.assertEqual(RemoteApp._classify_exists_id_type(["x"]), "string")
         self.assertEqual(RemoteApp._classify_exists_id_type([1]), "int")
         self.assertEqual(RemoteApp._classify_exists_id_type([1.1]), "float")
-        self.assertEqual(RemoteApp._classify_exists_id_type([Decimal("1.1")]), "decimal")
+        self.assertEqual(
+            RemoteApp._classify_exists_id_type([Decimal("1.1")]), "decimal"
+        )
         self.assertEqual(RemoteApp._classify_exists_id_type([1, 2.0]), "mixed")
 
     def test_generated_handler_unsupported_return_type_raises(self) -> None:


### PR DESCRIPTION
- Enable missing remote CRUD support required by the Salmonella cohort DAG: EXISTS_ONE / EXISTS_SOME for cohort definitions.
- Add focused unit coverage for the new remote exists behavior to prevent regressions in the cohort creation flow.