### PR TITLE
refactor(seqdb): LSP-3359 replace get_sample_identifiers_by_sample_ids with standard crud filter

### DIFF
--- a/gen_epix/seqdb/domain/repository/seq.py
+++ b/gen_epix/seqdb/domain/repository/seq.py
@@ -144,17 +144,6 @@ class BaseSeqRepository(BaseRepository):
         """
         raise NotImplementedError()
 
-    # TODO [LSP-3359] use standard crud method with filter rather than dedicated method
-    @abc.abstractmethod
-    def get_sample_identifiers_by_sample_ids(
-        self,
-        sample_ids: list[UUID],
-    ) -> list[model.SampleIdentifier]:
-        """
-        Retrieve only SampleIdentifier records for the given sample IDs.
-        """
-        raise NotImplementedError()
-
     @abc.abstractmethod
     def update_some_seq_distance_content(
         self,

--- a/gen_epix/seqdb/repositories/seq_dict.py
+++ b/gen_epix/seqdb/repositories/seq_dict.py
@@ -87,18 +87,6 @@ class SeqDictRepository(DictRepository, BaseSeqRepository):
             )
         return full_samples
 
-    def get_sample_identifiers_by_sample_ids(
-        self,
-        sample_ids: list[UUID],
-    ) -> list[model.SampleIdentifier]:
-        sample_id_set = set(sample_ids)
-        return [
-            obj
-            for obj in self.db[model.SampleIdentifier].values()
-            if isinstance(obj, model.SampleIdentifier)
-            and obj.internal_id in sample_id_set
-        ]
-
     def retrieve_seq_fasta(
         self,
         uow: BaseUnitOfWork,

--- a/gen_epix/seqdb/repositories/seq_sa.py
+++ b/gen_epix/seqdb/repositories/seq_sa.py
@@ -110,26 +110,6 @@ class SeqSARepository(SARepository, BaseSeqRepository):
 
             return full_samples
 
-    def get_sample_identifiers_by_sample_ids(
-        self,
-        sample_ids: list[UUID],
-    ) -> list[model.SampleIdentifier]:
-        if not sample_ids:
-            return []
-        sa_model_class = sa_model.SA_MODELS_BY_SERVICE_TYPE[enum.ServiceType.SEQ][
-            model.SampleIdentifier
-        ]
-        stmt: sa.Select = sa.select(sa_model_class).where(
-            sa_model_class.internal_id.in_(set(sample_ids))  # type: ignore[attr-defined]
-        )
-        mapper = self.get_mapper(model.SampleIdentifier)
-        with self.uow() as uow:
-            assert isinstance(uow, SAUnitOfWork)
-            return [
-                cast(model.SampleIdentifier, mapper.load(row[0]))
-                for row in uow.session.execute(stmt)
-            ]
-
     def retrieve_seq_fasta(
         self,
         uow: BaseUnitOfWork,

--- a/gen_epix/seqdb/services/seq/retrieve_sample.py
+++ b/gen_epix/seqdb/services/seq/retrieve_sample.py
@@ -1,5 +1,7 @@
 import gen_epix.seqdb.domain.command as command
 import gen_epix.seqdb.domain.model as model
+from gen_epix.fastapp import CrudOperation
+from gen_epix.filter.uuid_set import UuidSetFilter
 from gen_epix.seqdb.domain.repository import BaseSeqRepository
 from gen_epix.seqdb.domain.service import BaseSeqService
 
@@ -28,8 +30,16 @@ def seq_service_retrieve_sample_identifiers_by_id(
     sample_ids = cmd.sample_ids or []
     if not sample_ids:
         return []
+    user_id = cmd.user.id if cmd.user else None
     repository: BaseSeqRepository = self.repository  # type: ignore[assignment]
-    return repository.get_sample_identifiers_by_sample_ids(sample_ids)
+    with repository.uow() as uow:
+        return repository.crud(
+            uow,
+            user_id,
+            model.SampleIdentifier,
+            CrudOperation.READ_ALL,
+            filter=UuidSetFilter(key="internal_id", members=frozenset(sample_ids)),
+        )
 
 
 def seq_service_retrieve_samples_by_query(


### PR DESCRIPTION
## Summary
Replace the dedicated `get_sample_identifiers_by_sample_ids` repository method with the standard `crud(READ_ALL, filter=UuidSetFilter(...))` pattern.

## Changes
- Remove abstract method `get_sample_identifiers_by_sample_ids` from `BaseSeqRepository`
- Remove DICT and SA repository implementations of the method
- Update `seq_service_retrieve_sample_identifiers_by_id` to call `crud(READ_ALL, filter=UuidSetFilter(key="internal_id", ...))` directly

## Notes
No test changes required — existing integration tests cover both DICT and SA_SQLITE repo modes and pass unchanged.