### PR TITLE
LSP-3373: fix unique constraint violation on seq_classification and ast_prediction

### DIFF
--- a/gen_epix/commondb/repositories/sa_model/util.py
+++ b/gen_epix/commondb/repositories/sa_model/util.py
@@ -23,20 +23,44 @@ def create_table_args(
     assert model_class.ENTITY is not None
     entity: Entity = model_class.ENTITY
     uq_constraints = []
-    for field_names in entity.get_keys_field_names():
+    for key in entity.keys.values():
+        resolved = tuple(entity._fields[y]["alias"] for y in key.field_names)  # type: ignore[index]
         sa_field_names = (
-            [field_name_map.get(x, x) for x in field_names]
+            [field_name_map.get(x, x) for x in resolved]
             if field_name_map
-            else field_names
+            else list(resolved)
         )
         sa_field_name_str = "_".join(sa_field_names)
-        uq_constraints.append(
-            sa.UniqueConstraint(
-                *sa_field_names,
-                name=f"uq_{entity.table_name}_{sa_field_name_str}",
-                **kwargs,
+        constraint_name = f"uq_{entity.table_name}_{sa_field_name_str}"
+        if key.where_not_null:
+            w_resolved = tuple(
+                entity._fields[y]["alias"] for y in key.where_not_null  # type: ignore[index]
             )
-        )
+            w_sa = (
+                [field_name_map.get(x, x) for x in w_resolved]
+                if field_name_map
+                else list(w_resolved)
+            )
+            where_clause = sa.text(
+                " AND ".join(f"{f} IS NOT NULL" for f in w_sa)
+            )
+            uq_constraints.append(
+                sa.Index(
+                    constraint_name,
+                    *sa_field_names,
+                    unique=True,
+                    mssql_where=where_clause,
+                    sqlite_where=where_clause,
+                )
+            )
+        else:
+            uq_constraints.append(
+                sa.UniqueConstraint(
+                    *sa_field_names,
+                    name=constraint_name,
+                    **kwargs,
+                )
+            )
     if entity.schema_name:
         return entity.table_name, tuple(
             [*uq_constraints, {"schema": entity.schema_name}]

--- a/gen_epix/fastapp/domain/key.py
+++ b/gen_epix/fastapp/domain/key.py
@@ -11,10 +11,12 @@ class Key:
         self,
         field_names: str | tuple[str, ...],
         key_generator: Callable[[BaseModel], str] | None = None,
+        where_not_null: tuple[str, ...] | None = None,
     ):
         self._field_names: tuple[str, ...] = (
             (field_names,) if isinstance(field_names, str) else field_names
         )
+        self._where_not_null = where_not_null
 
         def _key_generator(field_names: tuple[str, ...], obj: BaseModel) -> str:
             return Key.DEFAULT_KEY_GENERATOR_SEPARATOR.join(
@@ -30,6 +32,12 @@ class Key:
     @property
     def field_names(self) -> tuple[str, ...]:
         return self._field_names
+
+    @property
+    def where_not_null(self) -> tuple[str, ...] | None:
+        """Field names whose corresponding column must be NOT NULL for the
+        unique index to fire. None means an unconditional unique constraint."""
+        return self._where_not_null
 
     @property
     def key_generator(self) -> Callable[[BaseModel], str]:

--- a/gen_epix/seqdb/domain/model/seq/classification.py
+++ b/gen_epix/seqdb/domain/model/seq/classification.py
@@ -5,7 +5,7 @@ from pydantic import Field, model_validator
 
 from gen_epix.commondb.domain.model import Model
 from gen_epix.commondb.domain.model.base import Model
-from gen_epix.fastapp.domain import Entity, create_keys, create_links
+from gen_epix.fastapp.domain import Entity, Key, create_keys, create_links
 from gen_epix.seqdb.domain import enum
 from gen_epix.seqdb.domain.model.seq.base import ContentMixin, QualityMixin
 from gen_epix.seqdb.domain.model.seq.category import SeqCategory
@@ -27,7 +27,9 @@ class SeqClassification(
         snake_case_plural_name="seq_classifications",
         table_name="seq_classification",
         persistable=True,
-        keys=create_keys({1: ("seq_id", "protocol_id")}),
+        keys=create_keys(
+            {1: Key(("seq_id", "protocol_id"), where_not_null=("seq_id",))}
+        ),
         links=create_links(
             {
                 1: ("sample_id", Sample, "sample"),
@@ -64,7 +66,9 @@ class AstPrediction(
         snake_case_plural_name="ast_predictions",
         table_name="ast_prediction",
         persistable=True,
-        keys=create_keys({1: ("seq_id", "protocol_id")}),
+        keys=create_keys(
+            {1: Key(("seq_id", "protocol_id"), where_not_null=("seq_id",))}
+        ),
         links=create_links(
             {
                 1: ("sample_id", Sample, "sample"),

--- a/test/seqdb/integration/test_seq_classification_constraint.py
+++ b/test/seqdb/integration/test_seq_classification_constraint.py
@@ -1,0 +1,128 @@
+"""
+Integration tests for the filtered unique index on SeqClassification and AstPrediction.
+
+The unique index on (seq_id, protocol_id) fires only when seq_id IS NOT NULL.
+This allows multiple pending rows (seq_id=NULL, same protocol_id) to coexist,
+while still preventing two resolved rows from sharing the same (seq_id, protocol_id).
+"""
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+# Importing repositories triggers domain initialization (set_model_class on all
+# entities), which must complete before create_table_args is evaluated.
+from gen_epix.seqdb.repositories.sa_model.seq.operational_data import (  # noqa: F401
+    AstPrediction as SAAstPrediction,
+    SeqClassification as SASeqClassification,
+)
+from gen_epix.seqdb.repositories.sa_model.seq.ref_data import Base
+from gen_epix.seqdb.domain import enum
+
+
+def _make_seq_classification(**kwargs) -> SASeqClassification:
+    defaults = dict(
+        id=uuid4(),
+        sample_id=uuid4(),
+        seq_id=None,
+        protocol_id=uuid4(),
+        primary_category_id=uuid4(),
+        format=enum.SeqClassificationFormat.PRIMARY_CATEGORY_ONLY,
+        content_hash=uuid4(),
+        content="{}",
+        qc_result=enum.QualityControlResult.PASS,
+        qc_score=1.0,
+    )
+    defaults.update(kwargs)
+    return SASeqClassification(**defaults)
+
+
+def _make_ast_prediction(**kwargs) -> SAAstPrediction:
+    defaults = dict(
+        id=uuid4(),
+        sample_id=uuid4(),
+        seq_id=None,
+        protocol_id=uuid4(),
+        format=enum.AstResultFormat.AST_RESULT_FORMAT1,
+        content_hash=uuid4(),
+        content="{}",
+        qc_result=enum.QualityControlResult.PASS,
+        qc_score=1.0,
+    )
+    defaults.update(kwargs)
+    return SAAstPrediction(**defaults)
+
+
+@pytest.fixture(scope="module")
+def engine():
+    """In-memory SQLite engine with the seq schema attached and FK checks off."""
+    e = sa.create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    with e.connect() as conn:
+        conn.execute(sa.text("PRAGMA foreign_keys=OFF"))
+        conn.execute(sa.text("ATTACH DATABASE ':memory:' AS seq"))
+        conn.commit()
+    Base.metadata.create_all(e)
+    yield e
+    e.dispose()
+
+
+class TestSeqClassificationFilteredIndex:
+    def test_null_seq_id_allows_multiple_pending_rows_and_enforces_non_null(
+        self, engine: sa.Engine
+    ) -> None:
+        protocol_id = uuid4()
+        # Two pending rows (seq_id=NULL) with the same protocol_id must coexist
+        with Session(engine) as s:
+            s.add(_make_seq_classification(seq_id=None, protocol_id=protocol_id))
+            s.add(_make_seq_classification(seq_id=None, protocol_id=protocol_id))
+            s.commit()
+
+        # Two resolved rows with the same (seq_id, protocol_id) must be rejected
+        shared_seq_id = uuid4()
+        with pytest.raises(sa.exc.IntegrityError):
+            with Session(engine) as s:
+                s.add(
+                    _make_seq_classification(
+                        seq_id=shared_seq_id, protocol_id=protocol_id
+                    )
+                )
+                s.add(
+                    _make_seq_classification(
+                        seq_id=shared_seq_id, protocol_id=protocol_id
+                    )
+                )
+                s.commit()
+
+
+class TestAstPredictionFilteredIndex:
+    def test_null_seq_id_allows_multiple_pending_rows_and_enforces_non_null(
+        self, engine: sa.Engine
+    ) -> None:
+        protocol_id = uuid4()
+        # Two pending rows (seq_id=NULL) with the same protocol_id must coexist
+        with Session(engine) as s:
+            s.add(_make_ast_prediction(seq_id=None, protocol_id=protocol_id))
+            s.add(_make_ast_prediction(seq_id=None, protocol_id=protocol_id))
+            s.commit()
+
+        # Two resolved rows with the same (seq_id, protocol_id) must be rejected
+        shared_seq_id = uuid4()
+        with pytest.raises(sa.exc.IntegrityError):
+            with Session(engine) as s:
+                s.add(
+                    _make_ast_prediction(
+                        seq_id=shared_seq_id, protocol_id=protocol_id
+                    )
+                )
+                s.add(
+                    _make_ast_prediction(
+                        seq_id=shared_seq_id, protocol_id=protocol_id
+                    )
+                )
+                s.commit()


### PR DESCRIPTION
## Summary
SQL Server treats NULL as a concrete value in unique constraints. When multiple
SeqClassification or AstPrediction rows are uploaded for samples without a sequence yet,
all share seq_id=NULL and collide on the (seq_id, protocol_id) constraint.
The fix replaces the plain constraint with a filtered unique index (WHERE seq_id IS NOT NULL).

## Changes
- `Key` gains an optional `where_not_null` parameter to declare a conditional uniqueness scope
- `create_table_args()` emits `sa.Index` with `mssql_where`/`sqlite_where` when `where_not_null` is set; falls back to `UniqueConstraint` for all other keys
- `SeqClassification` and `AstPrediction` entities updated to use the filtered key
- Integration tests added: pending rows (seq_id=NULL) coexist freely; resolved rows still enforce uniqueness
