### PR TITLE
feat: Add default timeout for CalculatePhylogeneticTreeCommand and RetrieveSimilarProfilesCommand

### DIFF
--- a/gen_epix/seqdb/services/remote_app.py
+++ b/gen_epix/seqdb/services/remote_app.py
@@ -38,8 +38,6 @@ class SeqdbRemoteApp(CommondbRemoteApp):
         command.RetrieveSampleIdentifiersByIdCommand: "/retrieve/sample_identifiers_by_ids",
         command.RetrieveSamplesByIdCommand: "/retrieve/samples_by_ids",
         command.RetrieveSamplesByQueryCommand: "/retrieve/sample_ids_by_query",
-        command.RetrieveBestSeqPerSampleCommand: "/retrieve/best_seq_per_sample",
-        command.RetrieveBestSeqProfilePerSampleCommand: "/retrieve/best_seq_profile_per_sample",
     }
 
     DEFAULT_HTTP_TIMEOUTS: dict[type[Command], float] = {
@@ -50,6 +48,7 @@ class SeqdbRemoteApp(CommondbRemoteApp):
         command.RetrieveSamplesByQueryCommand: 45.0,
         command.RetrieveBestSeqPerSampleCommand: 15.0,
         command.RetrieveBestSeqProfilePerSampleCommand: 15.0,
+        command.CalculatePhylogeneticTreeCommand: 45.0,
     }
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/gen_epix/seqdb/services/remote_app.py
+++ b/gen_epix/seqdb/services/remote_app.py
@@ -49,6 +49,7 @@ class SeqdbRemoteApp(CommondbRemoteApp):
         command.RetrieveBestSeqPerSampleCommand: 15.0,
         command.RetrieveBestSeqProfilePerSampleCommand: 15.0,
         command.CalculatePhylogeneticTreeCommand: 45.0,
+        command.RetrieveSimilarProfilesCommand: 45.0,
     }
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
- Add default timeout of 45 s for `CalculatePhylogeneticTreeCommand` and `RetrieveSimilarProfilesCommand` in seqdb remote app
- Removed duplicate entries in `SeqdbRemoteApp.ROUTE_MAP`