### PR TITLE
feat: Add profiling decorator for methods

### DIFF
--- a/gen_epix/util.py
+++ b/gen_epix/util.py
@@ -1,15 +1,18 @@
+import datetime
 import hashlib
+import inspect
 import tomllib
 import uuid
 from collections import defaultdict
 from collections.abc import Hashable, Iterable
-from functools import lru_cache
+from functools import lru_cache, wraps
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from uuid import UUID
 
 import ulid
 from pydantic import BaseModel, Field
+from pyinstrument import Profiler
 
 
 def generate_ulid() -> uuid.UUID:
@@ -254,3 +257,58 @@ def chunk_list(values: list, chunk_size: int | None) -> list[list]:
         return [values]
     n = len(values)
     return [values[i : i + chunk_size] for i in range(0, n, chunk_size)]
+
+
+def profile_method() -> Callable:
+    """Decorator method to profile a method using Pyinstrument.
+    The profiling output is written to a file named after the method and the current timestamp.
+    The decorator automatically determines whether the method is synchronous or asynchronous.
+    """
+
+    def decorator(method: Callable) -> Callable:
+
+        if inspect.iscoroutinefunction(method):
+
+            @wraps(method)
+            async def async_wrapper(*args, **kwargs):
+                profiler = Profiler(async_mode="enabled")
+
+                profiler.start()
+                try:
+                    return await method(*args, **kwargs)
+                finally:
+                    profiler.stop()
+
+                    filename = (
+                        f"{method.__name__}-"
+                        f"{datetime.datetime.now():%Y-%m-%d_%H-%M-%S}-"
+                        f"{uuid.uuid4()}.log"
+                    )
+
+                    with open(filename, "w", encoding="utf-8") as f:
+                        profiler.print(file=f, color=False)
+
+            return async_wrapper
+
+        @wraps(method)
+        def sync_wrapper(*args, **kwargs):
+            profiler = Profiler(async_mode="disabled")
+
+            profiler.start()
+            try:
+                return method(*args, **kwargs)
+            finally:
+                profiler.stop()
+
+                filename = (
+                    f"{method.__name__}-"
+                    f"{datetime.datetime.now():%Y-%m-%d_%H-%M-%S}-"
+                    f"{uuid.uuid4()}.log"
+                )
+
+                with open(filename, "w", encoding="utf-8") as f:
+                    profiler.print(file=f, color=False)
+
+        return sync_wrapper
+
+    return decorator

--- a/gen_epix/util.py
+++ b/gen_epix/util.py
@@ -259,11 +259,23 @@ def chunk_list(values: list, chunk_size: int | None) -> list[list]:
     return [values[i : i + chunk_size] for i in range(0, n, chunk_size)]
 
 
-def profile_method() -> Callable:
+def profile_method(path: str | None = None) -> Callable:
     """Decorator method to profile a method using Pyinstrument.
     The profiling output is written to a file named after the method and the current timestamp.
     The decorator automatically determines whether the method is synchronous or asynchronous.
     """
+
+    file_path = Path(path) if path else get_package_root()
+
+    def _write_profile(profiler: Profiler, method_name: str) -> None:
+        """Write profiler output to a timestamped log file."""
+        filename = (
+            f"{method_name}-"
+            f"{datetime.datetime.now(tz=datetime.timezone.utc):%Y-%m-%d_%H-%M-%S}-"
+            f"{uuid.uuid4()}.log"
+        )
+        with open(file_path / filename, "w", encoding="utf-8") as f:
+            profiler.print(file=f, color=False)
 
     def decorator(method: Callable) -> Callable:
 
@@ -278,15 +290,7 @@ def profile_method() -> Callable:
                     return await method(*args, **kwargs)
                 finally:
                     profiler.stop()
-
-                    filename = (
-                        f"{method.__name__}-"
-                        f"{datetime.datetime.now():%Y-%m-%d_%H-%M-%S}-"
-                        f"{uuid.uuid4()}.log"
-                    )
-
-                    with open(filename, "w", encoding="utf-8") as f:
-                        profiler.print(file=f, color=False)
+                    _write_profile(profiler, method.__name__)
 
             return async_wrapper
 
@@ -299,15 +303,7 @@ def profile_method() -> Callable:
                 return method(*args, **kwargs)
             finally:
                 profiler.stop()
-
-                filename = (
-                    f"{method.__name__}-"
-                    f"{datetime.datetime.now():%Y-%m-%d_%H-%M-%S}-"
-                    f"{uuid.uuid4()}.log"
-                )
-
-                with open(filename, "w", encoding="utf-8") as f:
-                    profiler.print(file=f, color=False)
+                _write_profile(profiler, method.__name__)
 
         return sync_wrapper
 

--- a/run.py
+++ b/run.py
@@ -190,6 +190,7 @@ class Run:
             "test/omopdb/integration",
             "test/general/docs",
             "test/end_to_end",
+            "test/util",
             # Not normally included, uncomment if needed
             # "test/casedb/performance",
             # "test/seqdb/performance",

--- a/test/util/test_profile_method.py
+++ b/test/util/test_profile_method.py
@@ -1,0 +1,54 @@
+import asyncio
+
+import pytest
+
+from gen_epix.util import profile_method
+
+
+def test_sync_returns_value(tmp_path):
+    @profile_method(path=str(tmp_path))
+    def sync_add(a, b):
+        return a + b
+
+    assert sync_add(1, 2) == 3
+
+
+def test_sync_writes_log_file(tmp_path):
+    @profile_method(path=str(tmp_path))
+    def sync_add(a, b):
+        return a + b
+
+    sync_add(1, 2)
+    logs = list(tmp_path.glob("sync_add-*.log"))
+    assert len(logs) == 1
+    assert logs[0].stat().st_size > 0
+
+
+def test_async_returns_value(tmp_path):
+    @profile_method(path=str(tmp_path))
+    async def async_add(a, b):
+        return a + b
+
+    assert asyncio.run(async_add(1, 2)) == 3
+
+
+def test_async_writes_log_file(tmp_path):
+    @profile_method(path=str(tmp_path))
+    async def async_add(a, b):
+        return a + b
+
+    asyncio.run(async_add(1, 2))
+    logs = list(tmp_path.glob("async_add-*.log"))
+    assert len(logs) == 1
+    assert logs[0].stat().st_size > 0
+
+
+def test_sync_propagates_exception(tmp_path):
+    @profile_method(path=str(tmp_path))
+    def boom():
+        raise ValueError("oops")
+
+    with pytest.raises(ValueError, match="oops"):
+        boom()
+    with pytest.raises(ValueError, match="oops"):
+        boom()


### PR DESCRIPTION
This PR adds a simple profiling decorator that can be used to profile a given method. The decorator is applied by placing it directly above the method definition:

```
@profile_method
def do_something():
    ...
```

This will generate a profiling report with the following filename structure:
`method_name + datetime.now() + uuid4()`

- Implemented a decorator to profile both synchronous and asynchronous methods using PyInstrument
- Profiling output is saved to a timestamped log file named after the method
- The decorator can also be used to profile FastAPI endpoints
