### PR TITLE
fix(ci): always start from a clean venv on cache miss

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~/.venv
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt') }}
+          key: ${{ runner.os }}-pip-v2-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt') }}
       - name: Install dependencies
         if: steps.cache-pip.outputs.cache-hit != 'true'
         run: |
@@ -65,7 +65,7 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~/.venv
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt') }}
+          key: ${{ runner.os }}-pip-v2-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt') }}
       - name: Check imports and formatting
         run: |
           source ~/.venv/bin/activate
@@ -94,7 +94,7 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~/.venv
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt') }}
+          key: ${{ runner.os }}-pip-v2-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt') }}
       - name: Run pylint and capture score
         id: pylint-run
         run: |
@@ -128,7 +128,7 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~/.venv
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt') }}
+          key: ${{ runner.os }}-pip-v2-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt') }}
       - name: Run mypy
         run: |
           source ~/.venv/bin/activate
@@ -156,7 +156,7 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~/.venv
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt') }}
+          key: ${{ runner.os }}-pip-v2-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt') }}
       - name: CI diagnostics (pytest stack)
         run: |
           source ~/.venv/bin/activate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,14 +42,10 @@ jobs:
           path: ~/.venv
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt') }}
       - name: Install dependencies
+        if: steps.cache-pip.outputs.cache-hit != 'true'
         run: |
-
-          if [[ ! -f ~/.venv/bin/activate ]]; then # Somehow there is sometimes a cached venv already at the start of the workflow
-            echo "Creating virtual environment"
-            python -m venv ~/.venv
-          else
-            echo "Using cached virtual environment"
-          fi
+          rm -rf ~/.venv
+          python -m venv ~/.venv
           source ~/.venv/bin/activate
           pip install -r requirements.txt
           pip install -r dev-requirements.txt


### PR DESCRIPTION
## Summary
Only create the venv when the cache misses, and always delete any pre-existing venv before creating a fresh one.

## Changes
- Added `if: steps.cache-pip.outputs.cache-hit != 'true'` to the Install dependencies step
- Replaced conditional venv reuse with `rm -rf ~/.venv` + fresh `python -m venv`
- Aligns gen-epix-api CI with the pattern already used in idsdb

## Notes
Previously, a stale or broken cached venv could be reused as-is, causing pip-not-found errors on GitHub Actions runners.