### PR TITLE
fix: use checkfirst=True in SARepository.create_all

### DIFF
--- a/gen_epix/fastapp/repositories/sa/repository.py
+++ b/gen_epix/fastapp/repositories/sa/repository.py
@@ -1501,7 +1501,7 @@ class SARepository(BaseRepository):
             metadata_set.add(cast(sa.MetaData, getattr(db_model_class, "metadata")))
 
         for metadata in metadata_set:
-            metadata.create_all(engine)
+            metadata.create_all(engine, checkfirst=True)
 
         # Create repository
         repository = cls(


### PR DESCRIPTION
Prevents DDL permission errors on read-only databases (e.g. source views) where schema objects already exist and the user has no CREATE permission.