### PR TITLE
refactor(test-client): generate hex strings as text instead of xlsx

### DIFF
--- a/run.py
+++ b/run.py
@@ -905,11 +905,11 @@ class Run:
         generate_uuids(n_rows=n_rows, n_cols=n_cols)
 
     def other_general_generate_hex_strings(
-        self, n_rows: int = 1000, n_cols: int = 100, length: int = 8
+        self, n_rows: int = 1000, length: int = 8
     ) -> None:
         from test.test_client.util import generate_hex_strings
 
-        generate_hex_strings(n_rows=n_rows, n_cols=n_cols, length=length)
+        generate_hex_strings(n_rows=n_rows, length=length)
 
     def other_general_run_linters(self) -> None:
         from test.test_client.linter import Linter

--- a/test/test_client/util.py
+++ b/test/test_client/util.py
@@ -38,17 +38,10 @@ def generate_uuids(n_rows: int = 1000, n_cols: int = 100) -> None:
     )
 
 
-def generate_hex_strings(
-    n_rows: int = 1000, n_cols: int = 100, length: int = 8
-) -> None:
-    hex_data = {
-        f"hex_string{i}": [f'"{secrets.token_hex(length // 2)}"' for j in range(n_rows)]
-        for i in range(n_cols)
-    }
-
-    df = pd.DataFrame.from_dict(hex_data)
-    xls_file = Path(__file__).parent.parent / "output" / "generated_hex_strings.xlsx"
-    df.to_excel(xls_file, sheet_name="hex_string", index=False)
+def generate_hex_strings(n_rows: int = 1000, length: int = 8) -> None:
+    hex_strings = [secrets.token_hex(length // 2) for _ in range(n_rows)]
+    txt_file = Path(__file__).parent.parent / "output" / "generated_hex_strings.txt"
+    txt_file.write_text("\n".join(hex_strings) + "\n", encoding="utf-8")
     print(
-        f"Total of {n_rows} hex strings times {df.shape[1]} columns generated and written to file {str(xls_file)}"
+        f"Total of {n_rows} hex strings generated and written to file {str(txt_file)}"
     )


### PR DESCRIPTION
## Summary
Update hex string generation to emit a newline-delimited text file.

## Changes
- Remove the obsolete column-count parameter from the runner and generator.
- Generate one unquoted hex string per line in `generated_hex_strings.txt`.

## Validation
- Pre-commit `isort` and `black` checks passed.
- Tests were not run.