### PR TITLE
refactor(caches): make all TTLCache instances named ClassVar attributes (LSP-3014)

### DIFF
--- a/gen_epix/casedb/services/abac.py
+++ b/gen_epix/casedb/services/abac.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import ClassVar
 from uuid import UUID
 
 from cachetools import TTLCache, cached
@@ -28,6 +29,8 @@ class AbacService(BaseAbacService):
         command.OrganizationAccessCasePolicyCrudCommand,
         command.OrganizationShareCasePolicyCrudCommand,
     )
+    _GET_CASE_ABAC_CACHE: ClassVar[TTLCache] = TTLCache(maxsize=1024, ttl=300)
+    _GET_REF_DATA_ACCESS_CACHE: ClassVar[TTLCache] = TTLCache(maxsize=1024, ttl=300)
 
     def register_policies(
         self,
@@ -206,13 +209,13 @@ class AbacService(BaseAbacService):
 
         # Invalidate cache
         # TODO: develop general system for caching and cache invalidation
-        self._get_user_by_id_cached.cache_clear()  # type: ignore[attr-defined]
-        self._get_case_abac_cached.cache_clear()  # type: ignore[attr-defined]
-        self._get_ref_data_access_cached.cache_clear()  # type: ignore[attr-defined]
+        AbacService._GET_USER_BY_ID_CACHE.clear()
+        AbacService._GET_CASE_ABAC_CACHE.clear()
+        AbacService._GET_REF_DATA_ACCESS_CACHE.clear()
 
         return user
 
-    @cached(cache=TTLCache(maxsize=1024, ttl=300))
+    @cached(cache=_GET_CASE_ABAC_CACHE)
     def _get_case_abac_cached(
         self,
         user_id: UUID,
@@ -603,7 +606,7 @@ class AbacService(BaseAbacService):
             )
         return self._get_ref_data_access_cached(user)
 
-    @cached(cache=TTLCache(maxsize=1024, ttl=300), key=lambda self, user: user.id)
+    @cached(cache=_GET_REF_DATA_ACCESS_CACHE, key=lambda self, user: user.id)
     def _get_ref_data_access_cached(self, user: model.User) -> model.RefDataAccess:
 
         if not self.role_set_map[CommonRoleSet.GE_REFDATA_ADMIN].isdisjoint(user.roles):

--- a/gen_epix/commondb/policies/has_system_outage_policy.py
+++ b/gen_epix/commondb/policies/has_system_outage_policy.py
@@ -1,4 +1,5 @@
 import time
+from typing import ClassVar
 
 from cachetools import TTLCache, cached
 
@@ -8,6 +9,9 @@ from gen_epix.fastapp import Command, CrudOperation
 
 
 class HasSystemOutagePolicy(BaseHasSystemOutagePolicy):
+    _IS_PERMITTED_CACHE: ClassVar[TTLCache] = TTLCache(maxsize=100, ttl=100)
+    _IS_ALLOWED_CACHE: ClassVar[TTLCache] = TTLCache(maxsize=10, ttl=10)
+
     def is_allowed(self, cmd: Command) -> bool:
         if isinstance(cmd, command.OutageCrudCommand):
             return True
@@ -21,16 +25,14 @@ class HasSystemOutagePolicy(BaseHasSystemOutagePolicy):
     def get_is_denied_exception(self) -> type[Exception]:
         return exc.ServiceUnavailableError
 
-    @cached(
-        cache=TTLCache(maxsize=100, ttl=100), key=lambda self, tgt_user: tgt_user.id
-    )
+    @cached(cache=_IS_PERMITTED_CACHE, key=lambda self, tgt_user: tgt_user.id)
     def _is_permitted(self, tgt_user: model.User) -> bool:
         return (
             self.outage_update_permission
             in self.system_service.app.user_manager.retrieve_user_permissions(tgt_user)
         )
 
-    @cached(cache=TTLCache(maxsize=10, ttl=10))
+    @cached(cache=_IS_ALLOWED_CACHE)
     def _is_allowed(self) -> bool:
         outages: list[model.Outage] = self.system_service.crud(  # type: ignore[assignment]
             command.OutageCrudCommand(

--- a/gen_epix/commondb/services/abac.py
+++ b/gen_epix/commondb/services/abac.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, ClassVar
 from uuid import UUID
 
 from cachetools import TTLCache, cached
@@ -27,6 +27,7 @@ from gen_epix.filter import (
 class AbacService(BaseAbacService):
 
     CACHE_INVALIDATION_COMMANDS: tuple[type[Command], ...] = tuple()
+    _GET_USER_BY_ID_CACHE: ClassVar[TTLCache] = TTLCache(maxsize=1024, ttl=300)
 
     def __init__(
         self,
@@ -72,7 +73,7 @@ class AbacService(BaseAbacService):
         retval = super().crud(cmd)
         # Invalidate cache
         if issubclass(type(cmd), AbacService.CACHE_INVALIDATION_COMMANDS):
-            self._get_user_by_id_cached.cache_clear()
+            AbacService._GET_USER_BY_ID_CACHE.clear()
         return retval
 
     def register_policies(
@@ -258,10 +259,10 @@ class AbacService(BaseAbacService):
 
         # Invalidate cache
         # TODO: develop general system for caching and cache invalidation
-        self._get_user_by_id_cached.cache_clear()
+        AbacService._GET_USER_BY_ID_CACHE.clear()
         return user
 
-    @cached(cache=TTLCache(maxsize=1024, ttl=300))
+    @cached(cache=_GET_USER_BY_ID_CACHE)
     def _get_user_by_id_cached(self, user_id: UUID) -> model.User:
         user: model.User = self.app.handle(
             self.user_crud_command_class(

--- a/gen_epix/commondb/services/organization.py
+++ b/gen_epix/commondb/services/organization.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, ClassVar
 from uuid import UUID
 
 from cachetools import TTLCache, cached
@@ -21,6 +21,7 @@ class OrganizationService(BaseOrganizationService):
         command.UserCrudCommand,
         command.UpdateUserCommand,
     )
+    _RETRIEVE_USER_BY_KEY_CACHE: ClassVar[TTLCache] = TTLCache(maxsize=1000, ttl=60)
 
     def __init__(
         self,
@@ -73,10 +74,10 @@ class OrganizationService(BaseOrganizationService):
         retval = super().crud(cmd)
         # Invalidate cache
         if issubclass(type(cmd), OrganizationService.CACHE_INVALIDATION_COMMANDS):
-            self.retrieve_user_by_key.cache_clear()  # type: ignore[attr-defined]
+            OrganizationService._RETRIEVE_USER_BY_KEY_CACHE.clear()
         return retval
 
-    @cached(cache=TTLCache(maxsize=1000, ttl=60))
+    @cached(cache=_RETRIEVE_USER_BY_KEY_CACHE)
     def retrieve_user_by_key(self, user_key: str) -> model.User:
         with self.repository.uow() as uow:
             return self.repository.retrieve_user_by_key(uow, user_key)
@@ -340,7 +341,7 @@ class OrganizationService(BaseOrganizationService):
             )
 
         # Invalidate cache for the user
-        self.retrieve_user_by_key.cache_clear()
+        OrganizationService._RETRIEVE_USER_BY_KEY_CACHE.clear()
         return updated_tgt_user
 
     def retrieve_organization_contacts(

--- a/gen_epix/commondb/services/system.py
+++ b/gen_epix/commondb/services/system.py
@@ -4,7 +4,7 @@ import re
 import string
 import tomllib
 from collections.abc import Hashable
-from typing import Any
+from typing import Any, ClassVar
 
 from cachetools import TTLCache, cached
 
@@ -21,6 +21,9 @@ from gen_epix.util import get_package_root
 
 class SystemService(BaseSystemService):
     REQUIREMENTS_FILE_NAME = "pyproject.toml"
+    _PARSE_AND_GET_PACKAGE_METADATA_CACHE: ClassVar[TTLCache] = TTLCache(
+        maxsize=1000, ttl=60
+    )
 
     def __init__(self, app: App, **kwargs: Any) -> None:
         super().__init__(app, **kwargs)
@@ -76,7 +79,7 @@ class SystemService(BaseSystemService):
         return packages
 
     @staticmethod
-    @cached(cache=TTLCache(maxsize=1000, ttl=60))
+    @cached(cache=_PARSE_AND_GET_PACKAGE_METADATA_CACHE)
     def _parse_and_get_package_metadata() -> list[model.PackageMetadata]:
         """
         Parse pyproject.toml, extract package names, and get their metadata.

--- a/test/casedb/unit/services/test_abac.py
+++ b/test/casedb/unit/services/test_abac.py
@@ -14,7 +14,7 @@ The tests handle the following scenarios:
 
 from __future__ import annotations
 
-from test.util.mock_compat import Mock
+from test.util.mock_compat import MagicMock, Mock, patch
 from types import SimpleNamespace
 from typing import Any
 from uuid import UUID, uuid4
@@ -413,17 +413,21 @@ class TestTempUpdateUserOrganization(BaseAbacTestCase):
         """When target org is same and not new user, returns early without side effects."""
         user = self.UserModelStub(self.user_id, self.org_id, {"ORG_USER"})
         cmd = self.create_update_user_cmd(user, self.org_id, is_new_user=False)
-        # Attach fake cache_clear targets to assert no calls
-        self.service._get_user_by_id_cached = SimpleNamespace(cache_clear=Mock())  # type: ignore[assignment]
-        self.service._get_case_abac_cached = SimpleNamespace(cache_clear=Mock())  # type: ignore[assignment]
-
-        retval = self.service.update_user_own_organization(cmd)
+        with (
+            patch.object(
+                AbacService, "_GET_USER_BY_ID_CACHE", new=MagicMock()
+            ) as user_cache,
+            patch.object(
+                AbacService, "_GET_CASE_ABAC_CACHE", new=MagicMock()
+            ) as case_abac_cache,
+        ):
+            retval = self.service.update_user_own_organization(cmd)
 
         assert retval is user
         self.repository.uow.assert_not_called()
         self.service.app.handle.assert_not_called()  # type: ignore[attr-defined]
-        self.service._get_user_by_id_cached.cache_clear.assert_not_called()  # type: ignore[attr-defined]
-        self.service._get_case_abac_cached.cache_clear.assert_not_called()  # type: ignore[attr-defined]
+        user_cache.clear.assert_not_called()
+        case_abac_cache.clear.assert_not_called()
 
     def test_happy_path_transfers_policies_and_updates_user(self) -> None:
         """Transfers policies to new org, deletes old user policies, creates new, updates user, and clears caches."""
@@ -487,10 +491,15 @@ class TestTempUpdateUserOrganization(BaseAbacTestCase):
             ),
         ]
 
-        self.service._get_user_by_id_cached = SimpleNamespace(cache_clear=Mock())  # type: ignore[assignment]
-        self.service._get_case_abac_cached = SimpleNamespace(cache_clear=Mock())  # type: ignore[assignment]
-
-        updated_user = self.service.update_user_own_organization(cmd)
+        with (
+            patch.object(
+                AbacService, "_GET_USER_BY_ID_CACHE", new=MagicMock()
+            ) as user_cache,
+            patch.object(
+                AbacService, "_GET_CASE_ABAC_CACHE", new=MagicMock()
+            ) as case_abac_cache,
+        ):
+            updated_user = self.service.update_user_own_organization(cmd)
 
         assert updated_user.organization_id == self.new_org_id
         assert self.service.app.handle.call_count == 9  # type: ignore[attr-defined]
@@ -498,5 +507,5 @@ class TestTempUpdateUserOrganization(BaseAbacTestCase):
         delete_usp_call = self.service.app.handle.call_args_list[5][0][0]  # type: ignore[attr-defined]
         assert delete_uap_call is not None
         assert delete_usp_call is not None
-        self.service._get_user_by_id_cached.cache_clear.assert_called_once()  # type: ignore[attr-defined]
-        self.service._get_case_abac_cached.cache_clear.assert_called_once()  # type: ignore[attr-defined]
+        user_cache.clear.assert_called_once()
+        case_abac_cache.clear.assert_called_once()


### PR DESCRIPTION
## Summary

Resolves **LSP-3014**. All 7 anonymous `cachetools.cached` cache instances across 5 files are promoted to named `ClassVar[TTLCache]` fields on their owning class, following the existing `BaseCaseService._RETRIEVE_COMPLETE_CASE_TYPE_CACHE` convention. This enables direct `.clear()` invalidation by class name, removes all `# type: ignore[attr-defined]` suppressions, and makes caches inspectable at runtime.

## Changes

| Class | New ClassVar | Callers updated |
|---|---|---|
| `casedb.AbacService` | `_GET_CASE_ABAC_CACHE`, `_GET_REF_DATA_ACCESS_CACHE` | 3 `cache_clear()` → `.clear()` |
| `commondb.AbacService` | `_GET_USER_BY_ID_CACHE` | 2 `cache_clear()` → `.clear()` |
| `OrganizationService` | `_RETRIEVE_USER_BY_KEY_CACHE` | 2 `cache_clear()` → `.clear()` |
| `SystemService` | `_PARSE_AND_GET_PACKAGE_METADATA_CACHE` | none (no callers) |
| `HasSystemOutagePolicy` | `_IS_PERMITTED_CACHE`, `_IS_ALLOWED_CACHE` | none (no callers) |

Tests in `test_abac.py` updated from `SimpleNamespace(cache_clear=Mock())` instance monkey-patching to `patch.object(AbacService, '_CACHE_NAME', new=MagicMock())`, with assertions updated to `.clear.assert_called_once()`.

## Notes

- Naming: method name stripped of leading `_` and `_cached` suffix, uppercased, with `_CACHE` suffix.
- `casedb.AbacService` inherits `_GET_USER_BY_ID_CACHE` from `commondb.AbacService`; no new import needed.
- `@staticmethod` / `@cached` decorator order on `SystemService._parse_and_get_package_metadata` preserved.
- `@lru_cache` and `@cached_property` usages are out of scope per ticket.

## Validation

- `pytest test/casedb/unit/services/test_abac.py` — all tests pass with updated mock strategy.
- Full test suite (`python run.py test_all`) passed locally.
