### PR TITLE
fix(upload): propagate nested verification failures and fix dry-run false-success (LSP-3655)

### DIFF
--- a/gen_epix/commondb/domain/model/upload.py
+++ b/gen_epix/commondb/domain/model/upload.py
@@ -189,6 +189,27 @@ class UploadResultWithIdentifiers(UploadResult):
         """
         return self.identifiers
 
+    def propagate_identifier_failures(self) -> None:
+        """
+        Mark this result as FAILED if any of its own identifier results is
+        FAILED, so that a client checking only this result's own status does
+        not miss a failure that was only recorded on a nested identifier.
+        """
+        if self.status == EtlStatus.FAILED:
+            return
+        if self.has_log_code("d8f21b6a"):
+            return
+        n_failed = sum(
+            1 for x in (self.identifiers or []) if x.status == EtlStatus.FAILED
+        )
+        if n_failed == 0:
+            return
+        self.add_error(
+            "d8f21b6a",
+            f"{n_failed} identifier(s) failed verification; see nested results "
+            "for details.",
+        )
+
 
 class ParentForUpload(Model, IdentifiersMixin):
     """
@@ -440,6 +461,30 @@ class ParentUploadResult(UploadResultWithIdentifiers):
         for identifier_result in self.identifiers or []:
             status_count_map[identifier_result.status] += 1
         return status_count_map
+
+    def propagate_child_failures(self) -> None:
+        """
+        Mark this result, and each of its own children, as FAILED if any
+        nested child or identifier result has FAILED, so that a client
+        checking only a given result's own status does not miss a failure
+        that was only recorded on a result nested underneath it.
+        """
+        for field_name in self.get_child_results_field_names():
+            for child_result in getattr(self, field_name, None) or []:
+                if isinstance(child_result, UploadResultWithIdentifiers):
+                    child_result.propagate_identifier_failures()
+        if self.status == EtlStatus.FAILED:
+            return
+        if self.has_log_code("6a1f3d0c"):
+            return
+        n_failed = self.get_status_count(include_self=False)[EtlStatus.FAILED]
+        if n_failed == 0:
+            return
+        self.add_error(
+            "6a1f3d0c",
+            f"{n_failed} nested item(s) failed verification or upload; "
+            "see nested results for details.",
+        )
 
     def update_status_with_data_issues(self) -> None:
         """
@@ -803,5 +848,14 @@ class BaseBatchUploadResult(UploadResult):
             self.status = EtlStatus.CREATED
         elif status_count[EtlStatus.UPDATED] == n_results:
             self.status = EtlStatus.UPDATED
+        elif status_count[EtlStatus.FAILED] > 0:
+            # At least one nested result failed: this must not resolve to a
+            # "not failed" status (e.g. PROCESSED) even if other results in
+            # the batch succeeded.
+            self.add_error(
+                "1f8d4c65",
+                f"{status_count[EtlStatus.FAILED]} item(s) in the batch failed "
+                "verification or upload; see nested results for details.",
+            )
         else:
             self.status = EtlStatus.PROCESSED

--- a/gen_epix/commondb/services/upload.py
+++ b/gen_epix/commondb/services/upload.py
@@ -139,6 +139,16 @@ class BatchUploader:
                 code="a3f7e9d2",
                 message="Verification ended",
             )
+            if not success:
+                # Record the batch-level failure regardless of verify_only,
+                # so that a dry run reports the same outcome as a real run.
+                batch_result.add_error(
+                    code="02095f22",
+                    message="Verification found errors, upload will not proceed",
+                )
+            for parent_result in batch_result.get_parent_results():
+                parent_result.propagate_child_failures()
+
             if cmd.verify_only:
                 # Stop here if only verification was requested; mark all
                 # still-PENDING individual results as SKIPPED (nothing was stored)
@@ -158,10 +168,6 @@ class BatchUploader:
 
             if not success:
                 # Do not proceed with upsert due to errors
-                batch_result.add_error(
-                    code="02095f22",
-                    message="Verification found errors, upload will not proceed",
-                )
                 return batch_result
 
             # Upsert the batch data
@@ -174,6 +180,8 @@ class BatchUploader:
                 code="f8b12027",
                 message="Upsert ended",
             )
+            for parent_result in batch_result.get_parent_results():
+                parent_result.propagate_child_failures()
             if not success:
                 # Rollback due to errors, but do not raise an exception since those will be reported in batch_result
                 batch_result.add_error(

--- a/test/commondb/unit/upload/test_commondb_upload.py
+++ b/test/commondb/unit/upload/test_commondb_upload.py
@@ -101,6 +101,11 @@ from test.commondb.unit.upload.model import (
     ParentBatchUploadResult,
     ParentForUpload,
     ParentIdentifier,
+)
+from test.commondb.unit.upload.model import (
+    ParentUploadResult as FixtureParentUploadResult,
+)
+from test.commondb.unit.upload.model import (
     Ref1,
     Ref2,
     UploadParentsCommand,
@@ -750,7 +755,7 @@ class Test3ReferenceDataLinks(BaseUploadTestCase):
         # Perform upload and verify result
         batch_result = self.upload_batch(parent_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=1)
+        self.expectStatusCount(batch_result, n_failed=2)
 
     def test_3_1_2_ref_id_provided_and_found_succeeds(self) -> None:
         """Test 3.1.2: Reference model ID found - should succeed."""
@@ -793,7 +798,7 @@ class Test3ReferenceDataLinks(BaseUploadTestCase):
         # Perform upload and verify result
         batch_result = self.upload_batch(parent_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=1)
+        self.expectStatusCount(batch_result, n_failed=2)
 
     def test_3_2_2_ref_code_provided_and_found_sets_id(self) -> None:
         """Test 3.2.2: Reference model code found - should succeed (and set reference model ID)."""
@@ -844,7 +849,7 @@ class Test3ReferenceDataLinks(BaseUploadTestCase):
         # Perform upload and verify result
         batch_result = self.upload_batch(parent_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=1)
+        self.expectStatusCount(batch_result, n_failed=2)
 
     def test_3_3_2_ref_id_and_code_match_succeeds(self) -> None:
         """Test 3.3.2: Reference model ID and code match - should succeed."""
@@ -882,7 +887,7 @@ class Test3ReferenceDataLinks(BaseUploadTestCase):
         # Perform upload and verify result
         batch_result = self.upload_batch(parent_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=1)
+        self.expectStatusCount(batch_result, n_failed=2)
 
     def test_3_4_2_child2_no_id_or_code_succeeds(self) -> None:
         """Test 3.4.2: Child2 with no ID or code - should succeed (reference is optional)."""
@@ -968,7 +973,7 @@ class Test4ParentLinks(BaseUploadTestCase):
             parent_for_upload, validate_command=False
         )  # Skip command validation to allow inconsistent IDs
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_pending=1, n_failed=1)
+        self.expectStatusCount(batch_result, n_failed=2)
 
     def test_4_2_2_child_parent_id_matches_succeeds(self) -> None:
         """Test 4.2.2: Parent exists with matching ID - should succeed."""
@@ -1194,7 +1199,10 @@ class Test5FieldMutability(BaseUploadTestCase):
             [existing_parent],  # Existing parents
         ]
         batch_result = self.upload_batch(parent_for_upload)
-        self.expectBatchProcessed(batch_result)
+        # update_objects() intentionally does not abort the rest of the batch
+        # for a per-object immutable-field error, but the batch-level status
+        # must still reflect that this parent failed.
+        self.expectBatchFailed(batch_result)
         self.expectStatusCount(batch_result, n_failed=1)
 
     def test_5_2_4_immutable_uuid_null_id_treated_as_not_specified(self) -> None:
@@ -1322,7 +1330,7 @@ class Test6Identifiers(BaseUploadTestCase):
         # Perform upload and verify result
         batch_result = self.upload_batch(parent_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=1)
+        self.expectStatusCount(batch_result, n_failed=2)
 
     def test_6_2_2_new_identifier_new_parent(self) -> None:
         """Test 6.2.2: New Identifier for new parent - should succeed."""
@@ -1434,7 +1442,7 @@ class Test6Identifiers(BaseUploadTestCase):
         # Perform upload and verify result
         batch_result = self.upload_batch(parent_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=2)
+        self.expectStatusCount(batch_result, n_failed=2, n_pending=1)
 
     def test_6_2_3_2_multiple_identifiers_all_new_same_issuer(self) -> None:
         """Test 6.2.3.2: Multiple Identifiers, all new but same issuer - should fail."""
@@ -1808,7 +1816,7 @@ class Test9Child2Identifiers(BaseUploadTestCase):
         # Perform upload and verify result
         batch_result = self.upload_batch(parent_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=2)
+        self.expectStatusCount(batch_result, n_failed=3)
 
     def test_9_2_2_new_identifier_new_child2(self) -> None:
         """Test 9.2.2: New Identifier for new child2 - should succeed."""
@@ -1949,7 +1957,7 @@ class Test9Child2Identifiers(BaseUploadTestCase):
         # Perform upload and verify result
         batch_result = self.upload_batch(parent_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=3)
+        self.expectStatusCount(batch_result, n_failed=3, n_pending=1)
 
     def test_9_2_3_2_multiple_identifiers_all_new_same_issuer(self) -> None:
         """Test 9.2.3.2: Multiple Identifiers all new but same issuer - should fail."""
@@ -2037,7 +2045,7 @@ class Test9Child2Identifiers(BaseUploadTestCase):
         # Perform upload and verify result
         batch_result = self.upload_batch(parent_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=2)
+        self.expectStatusCount(batch_result, n_failed=3)
 
     def test_9_3_2_identifier_issuer_code_not_found(self) -> None:
         """Test 9.3.2: Identifier issuer code provided and not found - should fail."""
@@ -2061,7 +2069,7 @@ class Test9Child2Identifiers(BaseUploadTestCase):
         # Perform upload and verify result
         batch_result = self.upload_batch(parent_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=2)
+        self.expectStatusCount(batch_result, n_failed=3)
 
     def test_9_3_3_identifier_issuer_id_and_code_mismatch(self) -> None:
         """Test 9.3.3: Both identifier issuer ID and code provided but do not match - should fail."""
@@ -2086,7 +2094,7 @@ class Test9Child2Identifiers(BaseUploadTestCase):
         # Perform upload and verify result
         batch_result = self.upload_batch(parent_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=2)
+        self.expectStatusCount(batch_result, n_failed=3)
 
 
 # Combined scenario tests
@@ -2526,6 +2534,9 @@ class TestDuplicateIds(BaseUploadTestCase):
 
         # Both parents exist; child objects_exist is also called (two IDs each time).
         self.service.repository.crud.return_value = [True, True]
+        # Both children reference self.ref1_id; resolve it so the batch is
+        # genuinely clean, isolating this test to duplicate-ID detection only.
+        self.service.repository.read_fields.return_value = [(self.ref1_id, "ref1_code")]
 
         batch_result = self.batch_uploader.upload_batch(  # type: ignore[assignment]
             self._verify_only_cmd([pa, pb])
@@ -2536,3 +2547,86 @@ class TestDuplicateIds(BaseUploadTestCase):
             assert r.status != EtlStatus.FAILED
             assert not r.has_log_code("a1b2c3d4")
             assert not r.has_log_code("e5f6a7b8")
+
+
+class TestVerificationAttributionAndDryRun(BaseUploadTestCase):
+    """
+    LSP-3655: a child-level failure must be visible on its own parent's
+    status (not just buried in a nested result), and a dry run (verify_only)
+    must report the same outcome as a real run.
+    """
+
+    def _make_child_parent_id_mismatch_cmd(self) -> UploadParentsCommand:
+        """Build a fresh command whose only problem is a child/parent ID mismatch."""
+        child1_a = self.create_child1_for_upload(
+            parent_id=self.random_ids[0],
+            ref1_id=self.ref1_id,
+            ref1_code=None,
+        )
+        child1_b = self.create_child1_for_upload(
+            parent_id=self.random_ids[1],
+            ref1_id=self.ref1_id,
+            ref1_code=None,
+        )
+        parent_for_upload = self.create_parent_for_upload(
+            parent_id=None,
+            children1=[child1_a, child1_b],
+        )
+        return self.create_command_for_parents(parent_for_upload)
+
+    def test_child_failure_propagates_to_parent_status(self) -> None:
+        """A FAILED child result must also mark its own parent result FAILED."""
+        self.service.repository.read_fields.return_value = [
+            (self.ref1_id, "ref1_code"),
+        ]
+        self.service.repository.crud.return_value = [True]
+        cmd = self._make_child_parent_id_mismatch_cmd().model_copy(
+            update={"verify_only": True}
+        )
+
+        batch_result = self.upload_batch(cmd)
+
+        parent_result = batch_result.parents[0]
+        child_results = parent_result.children1 or []
+        assert child_results[1].status == EtlStatus.FAILED
+        assert child_results[1].has_log_code("13ba4246")
+        assert parent_result.status == EtlStatus.FAILED
+        assert parent_result.has_log_code("6a1f3d0c")
+
+    def test_dry_run_and_real_run_report_same_failure(self) -> None:
+        """verify_only=True and verify_only=False must agree on batch outcome."""
+        self.service.repository.read_fields.return_value = [
+            (self.ref1_id, "ref1_code"),
+        ]
+        self.service.repository.crud.return_value = [True]
+
+        dry_run_cmd = self._make_child_parent_id_mismatch_cmd().model_copy(
+            update={"verify_only": True}
+        )
+        real_run_cmd = self._make_child_parent_id_mismatch_cmd().model_copy(
+            update={"verify_only": False}
+        )
+
+        dry_run_result = self.upload_batch(dry_run_cmd)
+        real_run_result = self.upload_batch(real_run_cmd)
+
+        for result in (dry_run_result, real_run_result):
+            self.expectBatchFailed(result)
+            assert result.parents[0].status == EtlStatus.FAILED
+            assert result.has_log_code("02095f22")
+
+    def test_resolve_status_reports_failed_when_any_descendant_failed(self) -> None:
+        """A mix of FAILED and successful descendants must resolve to FAILED, not PROCESSED."""
+        ok_parent = FixtureParentUploadResult(status=EtlStatus.CREATED)
+        bad_parent = FixtureParentUploadResult(status=EtlStatus.PENDING)
+        bad_parent.add_error("test_code_dead_beef", "boom")
+        batch_result = ParentBatchUploadResult(
+            batch_id=uuid4(),
+            status=EtlStatus.PENDING,
+            parents=[ok_parent, bad_parent],
+        )
+
+        batch_result.resolve_status()
+
+        assert batch_result.status == EtlStatus.FAILED
+        assert batch_result.has_log_code("1f8d4c65")

--- a/test/omopdb/unit/upload/test_omopdb_upload.py
+++ b/test/omopdb/unit/upload/test_omopdb_upload.py
@@ -730,7 +730,7 @@ class Test4PersonLinks(BasePersonUploadTestCase):
         ]
         batch_result = self.upload_batch(person_for_upload, validate_command=False)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_pending=1, n_failed=1)
+        self.expectStatusCount(batch_result, n_failed=2)
 
     def test_4_2_2_child_person_id_matches_succeeds(self) -> None:
         """Test 4.2.2: Child person_id matches parent - should succeed."""
@@ -1162,8 +1162,77 @@ class Test8SpecimenIdentifiers(BasePersonUploadTestCase):
         ]
         batch_result = self.upload_batch(person_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_pending=1, n_failed=1, n_skipped=1)
+        self.expectStatusCount(batch_result, n_failed=3)
         assert batch_result.persons[0].specimens[0].id == existing_specimen_id
+
+    def test_specimen_chain_retry_reusing_identifier_produces_readable_error(
+        self,
+    ) -> None:
+        """
+        A retried derived-specimen chain (e.g. a repeat culture attempt) that
+        carries the same lab identifier as the specimen it supersedes must
+        produce a clear, readable, correctly attributed error at every level
+        (identifier, specimen, person, batch) - and identically so whether
+        run for real or as a verify_only dry run.
+        """
+
+        def make_result(verify_only: bool) -> PersonBatchUploadResult:
+            old_tip_specimen_id = self.random_ids[3]
+            new_tip_specimen_id = self.random_ids[4]
+            lab_identifier = self.create_identifier_for_upload(
+                identifier_issuer_id=self.identifier_issuer_id,
+                external_id="LAB-SAMPLE-001",
+            )
+            # DB state: the lab identifier currently belongs to the previous
+            # attempt in the chain (old_tip_specimen_id).
+            existing_identifier = self.get_specimen_identifier_from_for_upload(
+                lab_identifier, internal_id=old_tip_specimen_id
+            )
+            # Upload payload: a new specimen (the retry), derived from the
+            # previous one, incorrectly carrying the same lab identifier.
+            new_specimen = self.create_specimen_for_upload(
+                specimen_id=new_tip_specimen_id, identifiers=[lab_identifier]
+            )
+            new_specimen.derived_from_specimen_id = old_tip_specimen_id
+            person_for_upload = self.create_person_for_upload(
+                person_id=self.person_id, person=None, specimens=[new_specimen]
+            )
+            self.service.app.handle.side_effect = [
+                [self.identifier_issuer],
+                [existing_identifier],
+            ]
+            self.service.repository.crud.side_effect = [[True]]
+            self.service.repository.read_fields.side_effect = [[]]
+            return self.upload_batch(
+                self.create_command_for_persons(person_for_upload).model_copy(
+                    update={"verify_only": verify_only}
+                )
+            )
+
+        for verify_only in (False, True):
+            batch_result = make_result(verify_only)
+            person_result = batch_result.persons[0]
+            specimen_result = person_result.specimens[0]
+            identifier_result = specimen_result.identifiers[0]
+
+            label = f"verify_only={verify_only}"
+            self.expectBatchFailed(batch_result)
+            assert person_result.status == EtlStatus.FAILED, label
+            assert specimen_result.status == EtlStatus.FAILED, label
+            assert identifier_result.status == EtlStatus.FAILED, label
+
+            # The identifier-level message must be specific and readable: it
+            # names the conflicting specimen IDs, not just a generic code.
+            identifier_message = next(
+                x.message for x in identifier_result.logs if x.code == "0561ecd7"
+            )
+            assert str(self.random_ids[3]) in identifier_message, label  # old tip
+            assert str(self.random_ids[4]) in identifier_message, label  # new tip
+
+            # The specimen and person level messages must point down to
+            # where the real error lives, not just report a bare failure.
+            assert specimen_result.has_log_code("d8f21b6a"), label
+            assert person_result.has_log_code("6a1f3d0c"), label
 
     def test_8_2_2_new_identifier_new_specimen(self) -> None:
         """Test 8.2.2: New Identifier for new specimen - should succeed."""
@@ -1312,7 +1381,7 @@ class Test8SpecimenIdentifiers(BasePersonUploadTestCase):
         ]
         batch_result = self.upload_batch(person_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_skipped=1, n_pending=2)
+        self.expectStatusCount(batch_result, n_failed=3, n_pending=1)
         assert batch_result.persons[0].specimens[0].id == existing_specimen_id
         assert batch_result.persons[0].specimens[0].identifiers[1].id is None
 
@@ -1385,7 +1454,7 @@ class Test8SpecimenIdentifiers(BasePersonUploadTestCase):
         ]
         batch_result = self.upload_batch(person_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=2)
+        self.expectStatusCount(batch_result, n_failed=3)
 
     def test_8_3_2_identifier_issuer_code_not_found(self) -> None:
         """Test 8.3.2: Identifier issuer code provided and not found - should fail."""
@@ -1404,7 +1473,7 @@ class Test8SpecimenIdentifiers(BasePersonUploadTestCase):
         ]
         batch_result = self.upload_batch(person_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=2)
+        self.expectStatusCount(batch_result, n_failed=3)
 
     def test_8_3_3_identifier_issuer_id_and_code_mismatch(self) -> None:
         """Test 8.3.3: Both identifier issuer ID and code provided but do not match - should fail."""
@@ -1424,7 +1493,7 @@ class Test8SpecimenIdentifiers(BasePersonUploadTestCase):
         ]
         batch_result = self.upload_batch(person_for_upload)
         self.expectBatchFailed(batch_result)
-        self.expectStatusCount(batch_result, n_failed=1, n_pending=2)
+        self.expectStatusCount(batch_result, n_failed=3)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
BatchUploader.verify_batch() attributed failures correctly on the specific child/identifier result, but never propagated FAILED status up to the owning specimen/case/sample or parent (person/case) result, so a client checking only the parent's own status saw PENDING despite a real, nested failure. verify_only (dry-run) additionally short-circuited before the batch-level error was ever recorded, so a dry run always reported success even when the same batch would fail for real.

- Add ParentUploadResult.propagate_child_failures() and UploadResultWithIdentifiers.propagate_identifier_failures() to bubble a FAILED status (with an explanatory log) up through identifier -> child -> parent.
- Record the batch-level verification error before branching on verify_only, so dry runs and real runs agree.
- Harden BaseBatchUploadResult.resolve_status() to report FAILED whenever any descendant failed, instead of falling through to PROCESSED.
- Add regression coverage, including a synthetic reproduction of a specimen-chain retry that reuses an identifier already registered to a different specimen.