### PR TITLE
fix(config): avoid expensive Dynaconf deep copies

### DIFF
--- a/gen_epix/commondb/config/cfg.py
+++ b/gen_epix/commondb/config/cfg.py
@@ -240,33 +240,37 @@ class AppCfg(BaseAppCfg):
 
     def _init_validate_settings(self) -> None:
         """Validate settings and apply defaults to all services and repositories."""
-        # Map timestamp and id factories
         from gen_epix.commondb.domain.enum import (  # noqa: PLC0415
             IdFactory,
             TimestampFactory,
         )
 
+        # 1. Map timestamp and id factory strings to factory objects
         defaults_cfg = self._cfg["service"]["defaults"]["props"]
-        timestamp_factory = getattr(
-            TimestampFactory,
-            defaults_cfg["timestamp_factory"],
+        defaults_cfg["timestamp_factory"] = getattr(
+            TimestampFactory, defaults_cfg["timestamp_factory"]
         )
-        id_factory = getattr(IdFactory, defaults_cfg["id_factory"])
-        defaults_cfg["timestamp_factory"] = timestamp_factory
-        defaults_cfg["id_factory"] = id_factory
+        defaults_cfg["id_factory"] = getattr(IdFactory, defaults_cfg["id_factory"])
 
-        # Map default repository type
+        # 2. Map default repository type string to enum member
         repository_type = getattr(
             self._repository_type_enum, self._cfg["repository"]["defaults"]["type"]
         )
         self._cfg["repository"]["defaults"]["type"] = repository_type
 
-        # Get class for and apply defaults to each service and repository
+        # 3. Apply defaults and dynamically import classes
         for service_type in self._service_type_enum:
             service_type_str = service_type.value.lower()
+
+            # Ensure target service dict exists
             if service_type_str not in self._cfg["service"]:
-                self._cfg["service"].update({service_type_str: {}})
-            service_cfg = self._cfg["service"][service_type_str]
+                self._cfg["service"][service_type_str] = {}
+
+            # Merge defaults with custom settings (custom values on the right override defaults)
+            service_cfg = (
+                self._cfg["service"]["defaults"]
+                | self._cfg["service"][service_type_str]
+            )
 
             # Get class for service
             service_module = service_cfg["module"]
@@ -274,16 +278,17 @@ class AppCfg(BaseAppCfg):
             service_cfg["class"] = getattr(
                 importlib.import_module(service_module), service_class_name
             )
-
-            # Apply defaults to service
-            orig_cfg = copy.deepcopy(service_cfg)
-            service_cfg.update(self._cfg["service"]["defaults"])
-            service_cfg.update(orig_cfg)
+            self._cfg["service"][service_type_str] = service_cfg
 
             # Skip if the service does not have a repository
             if service_type_str not in self._cfg["repository"]:
                 continue
-            repository_cfg = self._cfg["repository"][service_type_str]
+
+            # Merge repository defaults with custom settings
+            repository_cfg = (
+                self._cfg["repository"]["defaults"]
+                | self._cfg["repository"][service_type_str]
+            )
 
             # Get class for repository
             repository_module = repository_cfg["module"]
@@ -291,11 +296,7 @@ class AppCfg(BaseAppCfg):
             repository_cfg["class"] = getattr(
                 importlib.import_module(repository_module), repository_class_name
             )
-
-            # Apply defaults to repository, if the service has a repository
-            orig_cfg = copy.deepcopy(repository_cfg)
-            repository_cfg.update(self._cfg["repository"]["defaults"])
-            repository_cfg.update(orig_cfg)
+            self._cfg["repository"][service_type_str] = repository_cfg
 
     def copy_repository_files(
         self,

--- a/gen_epix/commondb/config/cfg.py
+++ b/gen_epix/commondb/config/cfg.py
@@ -245,20 +245,20 @@ class AppCfg(BaseAppCfg):
             TimestampFactory,
         )
 
-        # 1. Map timestamp and id factory strings to factory objects
+        # Map timestamp and id factory strings to factory objects
         defaults_cfg = self._cfg["service"]["defaults"]["props"]
         defaults_cfg["timestamp_factory"] = getattr(
             TimestampFactory, defaults_cfg["timestamp_factory"]
         )
         defaults_cfg["id_factory"] = getattr(IdFactory, defaults_cfg["id_factory"])
 
-        # 2. Map default repository type string to enum member
+        # Map default repository type string to enum member
         repository_type = getattr(
             self._repository_type_enum, self._cfg["repository"]["defaults"]["type"]
         )
         self._cfg["repository"]["defaults"]["type"] = repository_type
 
-        # 3. Apply defaults and dynamically import classes
+        # Apply defaults and dynamically import classes
         for service_type in self._service_type_enum:
             service_type_str = service_type.value.lower()
 


### PR DESCRIPTION
## Summary

Refactor `AppCfg._init_validate_settings` to remove unnecessary `copy.deepcopy()` calls on Dynaconf configuration objects.

This is a blocking performance change for the current Dynaconf version. After upgrading from Dynaconf 3.2.13 to 3.3.2, `DynaconfCore.__deepcopy__` became sufficiently expensive to increase pytest collection time from approximately 10 seconds to 3 minutes, slowing every test-driven development and CI feedback cycle.

## Changes

- Convert service and repository configuration merges to regular Python dictionary operations.
- Preserve the existing precedence rule: service or repository-specific values override defaults.
- Preserve dynamic resolution of timestamp factories, ID factories, repository types, service classes, and repository classes.
- Ensure missing service configuration entries are initialized before defaults are merged.
- Store the merged dictionaries back into the application configuration for downstream consumers.
- Remove the Dynaconf deep-copy path from service and repository default application.

## Why This Is Blocking

The previous implementation deep-copied Dynaconf-backed configuration objects once per configured service and repository. With Dynaconf 3.3.2, that behavior makes test collection and local development feedback prohibitively slow, increasing collection time from roughly 10 seconds to roughly 3 minutes.

This change converts the configuration objects to regular dictionaries before applying defaults. The expected collection time is approximately 20 seconds while retaining the established configuration behavior. Until this is merged, the slower collection path remains on the shared development branch and continues to block practical test execution and CI iteration.

## Validation

- `git diff --check dev...HEAD` passed.

## Notes

The change is limited to `gen_epix/commondb/config/cfg.py`. No API contract, repository backend, authentication behavior, or cross-repository client behavior is changed.
