### PR TITLE
LSP-3453: create template R script to connect to CASEDB

### DIFF
--- a/gen_epix/casedb/services/remote_app.R
+++ b/gen_epix/casedb/services/remote_app.R
@@ -1,0 +1,91 @@
+# Minimal CASEDB HTTP interface for the SALM analysis workflow.
+#
+# Local use:
+# install.packages(c("chromote", "httr2"))
+# source("gen_epix/commondb/services/remote_app.R")
+# source("gen_epix/casedb/services/remote_app.R")
+# token <- login_with_chromote("http://localhost:5173")
+# result <- retrieve_cases_by_query("http://localhost:8000", token)
+
+SALM_CASE_TYPE_ID <- "a2f25555-3444-43cc-914d-dbaa6703f21b"
+SALM_CGMLST_DISTANCE_COL_ID <- "c7daf551-daa4-4ed2-b082-e4c41f4e58c3"
+
+casedb_post <- function(
+    base_url,
+    path,
+    body,
+    access_token,
+    timeout_seconds,
+    post_json
+) {
+    url <- commondb_url(base_url, paste0("/v1", path))
+    post_json(
+        url = url,
+        body = body,
+        access_token = access_token,
+        timeout_seconds = timeout_seconds
+    )
+}
+
+retrieve_cases_by_query <- function(
+    base_url,
+    access_token,
+    case_type_id = SALM_CASE_TYPE_ID,
+    timeout_seconds = 45,
+    post_json = commondb_post_json
+) {
+    body <- list(case_type_id = case_type_id)
+    casedb_post(
+        base_url,
+        "/retrieve/case_ids_by_query",
+        body,
+        access_token,
+        timeout_seconds,
+        post_json
+    )
+}
+
+retrieve_cases_by_id <- function(
+    base_url,
+    access_token,
+    case_ids,
+    case_type_id = SALM_CASE_TYPE_ID,
+    timeout_seconds = 45,
+    post_json = commondb_post_json
+) {
+    body <- list(case_type_id = case_type_id, case_ids = case_ids)
+    casedb_post(
+        base_url,
+        "/retrieve/cases_by_ids",
+        body,
+        access_token,
+        timeout_seconds,
+        post_json
+    )
+}
+
+retrieve_phylogenetic_tree_by_cases <- function(
+    base_url,
+    access_token,
+    case_ids,
+    genetic_distance_col_id = SALM_CGMLST_DISTANCE_COL_ID,
+    tree_algorithm_code = "SLINK",
+    case_type_id = SALM_CASE_TYPE_ID,
+    timeout_seconds = 45,
+    post_json = commondb_post_json
+) {
+    body <- list(
+        case_type_id = case_type_id,
+        genetic_distance_col_id = genetic_distance_col_id,
+        tree_algorithm_code = tree_algorithm_code,
+        case_ids = case_ids
+    )
+    casedb_post(
+        base_url,
+        "/calculate/phylogenetic_tree",
+        body,
+        access_token,
+        timeout_seconds,
+        post_json
+    )
+}

--- a/gen_epix/commondb/services/remote_app.R
+++ b/gen_epix/commondb/services/remote_app.R
@@ -21,12 +21,40 @@ chromote_access_token_value <- function(evaluation_result) {
     access_token
 }
 
-read_chromote_access_token <- function(chromote_session) {
+read_chromote_access_token <- function(
+    chromote_session,
+    timeout_seconds = 2
+) {
     evaluation_result <- chromote_session$Runtime$evaluate(
         CHROMOTE_ACCESS_TOKEN_SCRIPT,
-        returnByValue = TRUE
+        returnByValue = TRUE,
+        timeout_ = timeout_seconds
     )
     chromote_access_token_value(evaluation_result)
+}
+
+is_chromote_navigation_error <- function(error) {
+    message <- conditionMessage(error)
+    transient_messages <- c(
+        "timed out waiting for response to command Runtime.evaluate",
+        "Cannot find context with specified id",
+        "Execution context was destroyed"
+    )
+    any(vapply(transient_messages, grepl, logical(1), x = message, fixed = TRUE))
+}
+
+handle_chromote_login_read_error <- function(error) {
+    if (is_chromote_navigation_error(error)) {
+        return(NULL)
+    }
+    stop(error)
+}
+
+read_chromote_access_token_during_login <- function(chromote_session) {
+    tryCatch(
+        read_chromote_access_token(chromote_session),
+        error = handle_chromote_login_read_error
+    )
 }
 
 login_with_chromote <- function(
@@ -46,7 +74,7 @@ login_with_chromote <- function(
 
     deadline <- Sys.time() + timeout_seconds
     while (Sys.time() < deadline) {
-        access_token <- read_chromote_access_token(chromote_session)
+        access_token <- read_chromote_access_token_during_login(chromote_session)
         if (!is.null(access_token)) {
             return(access_token)
         }

--- a/gen_epix/commondb/services/remote_app.R
+++ b/gen_epix/commondb/services/remote_app.R
@@ -1,0 +1,91 @@
+# Shared helpers for calling a Gen-EpiX app from R.
+
+CHROMOTE_ACCESS_TOKEN_SCRIPT <- paste0(
+    "(() => {",
+    "const key = Object.keys(sessionStorage)",
+    ".find((key) => key.startsWith('oidc.user:'));",
+    "if (!key) return null;",
+    "const user = JSON.parse(sessionStorage.getItem(key));",
+    "return user.access_token || null;",
+    "})()"
+)
+
+chromote_access_token_value <- function(evaluation_result) {
+    access_token <- evaluation_result$result$value
+    if (!is.character(access_token) || length(access_token) != 1L) {
+        return(NULL)
+    }
+    if (!nzchar(access_token)) {
+        return(NULL)
+    }
+    access_token
+}
+
+read_chromote_access_token <- function(chromote_session) {
+    evaluation_result <- chromote_session$Runtime$evaluate(
+        CHROMOTE_ACCESS_TOKEN_SCRIPT,
+        returnByValue = TRUE
+    )
+    chromote_access_token_value(evaluation_result)
+}
+
+login_with_chromote <- function(
+    login_url,
+    timeout_seconds = 300,
+    poll_interval_seconds = 1
+) {
+    if (!requireNamespace("chromote", quietly = TRUE)) {
+        stop("Package 'chromote' is required for browser login.", call. = FALSE)
+    }
+
+    chromote_session <- chromote::ChromoteSession$new()
+    on.exit(chromote_session$close(), add = TRUE)
+    chromote_session$go_to(login_url)
+    chromote_session$view()
+    message("Complete the login in the Chromote viewer.")
+
+    deadline <- Sys.time() + timeout_seconds
+    while (Sys.time() < deadline) {
+        access_token <- read_chromote_access_token(chromote_session)
+        if (!is.null(access_token)) {
+            return(access_token)
+        }
+        Sys.sleep(poll_interval_seconds)
+    }
+
+    stop("Timed out waiting for the browser login to complete.", call. = FALSE)
+}
+
+commondb_url <- function(base_url, path) {
+    normalized_base_url <- sub("/+$", "", base_url)
+    normalized_path <- sub("^/*", "/", path)
+    paste0(normalized_base_url, normalized_path)
+}
+
+commondb_post_json <- function(
+    url,
+    body,
+    access_token,
+    timeout_seconds = 45
+) {
+    if (!requireNamespace("httr2", quietly = TRUE)) {
+        stop("Package 'httr2' is required for HTTP requests.", call. = FALSE)
+    }
+    is_valid_access_token <- is.character(access_token) &&
+        length(access_token) == 1L &&
+        nzchar(access_token)
+    if (!is_valid_access_token) {
+        stop("A non-empty access token is required.", call. = FALSE)
+    }
+
+    request <- httr2::request(url)
+    request <- httr2::req_headers(
+        request,
+        Authorization = paste("Bearer", access_token)
+    )
+    request <- httr2::req_body_json(request, body, auto_unbox = TRUE)
+    request <- httr2::req_timeout(request, timeout_seconds)
+
+    response <- httr2::req_perform(request)
+    httr2::resp_body_json(response, simplifyVector = FALSE)
+}

--- a/test/r/test_remote_app.R
+++ b/test/r/test_remote_app.R
@@ -1,0 +1,59 @@
+repo_root <- normalizePath(".")
+
+source(file.path(repo_root, "gen_epix", "commondb", "services", "remote_app.R"))
+source(file.path(repo_root, "gen_epix", "casedb", "services", "remote_app.R"))
+
+record_request <- function(url, body, access_token, timeout_seconds) {
+    list(
+        url = url,
+        body = body,
+        access_token = access_token,
+        timeout_seconds = timeout_seconds
+    )
+}
+
+query_request <- retrieve_cases_by_query(
+    base_url = "http://localhost:8000/",
+    access_token = "test-token",
+    post_json = record_request
+)
+stopifnot(
+    identical(query_request$url, "http://localhost:8000/v1/retrieve/case_ids_by_query"),
+    identical(query_request$body, list(case_type_id = SALM_CASE_TYPE_ID)),
+    identical(query_request$access_token, "test-token")
+)
+
+case_ids <- c("case-1", "case-2")
+cases_request <- retrieve_cases_by_id(
+    base_url = "http://localhost:8000",
+    access_token = "test-token",
+    case_ids = case_ids,
+    post_json = record_request
+)
+stopifnot(
+    identical(cases_request$url, "http://localhost:8000/v1/retrieve/cases_by_ids"),
+    identical(
+        cases_request$body,
+        list(case_type_id = SALM_CASE_TYPE_ID, case_ids = case_ids)
+    )
+)
+
+tree_request <- retrieve_phylogenetic_tree_by_cases(
+    base_url = "http://localhost:8000",
+    access_token = "test-token",
+    case_ids = case_ids,
+    post_json = record_request
+)
+stopifnot(
+    identical(tree_request$url, "http://localhost:8000/v1/calculate/phylogenetic_tree"),
+    identical(tree_request$body$case_type_id, SALM_CASE_TYPE_ID),
+    identical(tree_request$body$genetic_distance_col_id, SALM_CGMLST_DISTANCE_COL_ID),
+    identical(tree_request$body$tree_algorithm_code, "SLINK"),
+    identical(tree_request$body$case_ids, case_ids)
+)
+
+token_result <- list(result = list(value = "browser-token"))
+stopifnot(identical(chromote_access_token_value(token_result), "browser-token"))
+
+missing_token_result <- list(result = list(subtype = "null"))
+stopifnot(is.null(chromote_access_token_value(missing_token_result)))

--- a/test/r/test_remote_app.R
+++ b/test/r/test_remote_app.R
@@ -57,3 +57,22 @@ stopifnot(identical(chromote_access_token_value(token_result), "browser-token"))
 
 missing_token_result <- list(result = list(subtype = "null"))
 stopifnot(is.null(chromote_access_token_value(missing_token_result)))
+
+timed_out_runtime <- new.env()
+timed_out_runtime$evaluate <- function(...) {
+    stop("Chromote: timed out waiting for response to command Runtime.evaluate")
+}
+timed_out_session <- list(Runtime = timed_out_runtime)
+stopifnot(is.null(read_chromote_access_token_during_login(timed_out_session)))
+
+disconnected_runtime <- new.env()
+disconnected_runtime$evaluate <- function(...) {
+    stop("Chromote: websocket disconnected")
+}
+disconnected_session <- list(Runtime = disconnected_runtime)
+capture_error_message <- function(error) conditionMessage(error)
+disconnected_error <- tryCatch(
+    read_chromote_access_token_during_login(disconnected_session),
+    error = capture_error_message
+)
+stopifnot(identical(disconnected_error, "Chromote: websocket disconnected"))

--- a/test/r/test_remote_app_e2e.R
+++ b/test/r/test_remote_app_e2e.R
@@ -1,0 +1,69 @@
+# Interactive end-to-end test for the CASEDB R remote app.
+#
+# Prerequisites:
+# - CASEDB API at https://127.0.0.1:8000 using SA_SQLITE_DEMO
+# - CASEDB UI at https://localhost:5010
+# - Mock OIDC server at https://localhost:5443
+#
+# Run from the gen-epix-api repository root:
+# Rscript test/r/test_remote_app_e2e.R
+
+repo_root <- normalizePath(".")
+certificate_path <- normalizePath(file.path(repo_root, "cert", "cert.pem"))
+
+Sys.setenv(CURL_CA_BUNDLE = certificate_path)
+
+source(file.path(repo_root, "gen_epix", "commondb", "services", "remote_app.R"))
+source(file.path(repo_root, "gen_epix", "casedb", "services", "remote_app.R"))
+
+CASEDB_URL <- "https://127.0.0.1:8000"
+CASEDB_LOGIN_URL <- "https://localhost:5010"
+DEMO_SALM_CASE_TYPE_ID <- "6e5b6a81-ccca-408f-8591-649dce8ccbeb"
+DEMO_SALM_CGMLST_COL_ID <- "35174fb1-055c-46a9-98b5-1ef016e0d895"
+N_CASES_FOR_TREE <- 3L
+
+message("Click LOGIN for the Dum My CASEDB_ROOT user in the Chromote viewer.")
+access_token <- login_with_chromote(CASEDB_LOGIN_URL)
+
+query_result <- retrieve_cases_by_query(
+    CASEDB_URL,
+    access_token,
+    case_type_id = DEMO_SALM_CASE_TYPE_ID
+)
+case_ids <- unlist(query_result$case_ids, use.names = FALSE)
+
+if (length(case_ids) < N_CASES_FOR_TREE) {
+    stop("CASEDB returned fewer than three demo cases.", call. = FALSE)
+}
+
+selected_case_ids <- head(case_ids, N_CASES_FOR_TREE)
+cases <- retrieve_cases_by_id(
+    CASEDB_URL,
+    access_token,
+    case_ids = selected_case_ids,
+    case_type_id = DEMO_SALM_CASE_TYPE_ID
+)
+returned_case_ids <- vapply(cases, `[[`, character(1), "id")
+
+if (!setequal(returned_case_ids, selected_case_ids)) {
+    stop("CASEDB did not return all requested cases.", call. = FALSE)
+}
+
+tree <- retrieve_phylogenetic_tree_by_cases(
+    CASEDB_URL,
+    access_token,
+    case_ids = selected_case_ids,
+    genetic_distance_col_id = DEMO_SALM_CGMLST_COL_ID,
+    case_type_id = DEMO_SALM_CASE_TYPE_ID
+)
+
+if (!identical(tree$tree_algorithm_code, "SLINK") || !nzchar(tree$newick_repr)) {
+    stop("CASEDB did not return a valid SLINK tree.", call. = FALSE)
+}
+
+cat("\nCASEDB R end-to-end test succeeded.\n")
+cat("Cases matched:", length(case_ids), "\n")
+cat("Cases retrieved:", length(cases), "\n")
+cat("Retrieved case IDs:\n", paste(returned_case_ids, collapse = "\n"), "\n")
+cat("Tree algorithm:", tree$tree_algorithm_code, "\n")
+cat("Newick tree:\n", tree$newick_repr, "\n")


### PR DESCRIPTION
## Summary
Add a minimal R interface for authenticated SALM analysis against CASEDB.

## Changes
- Retrieve an OIDC access token through an interactive Chromote login.
- Retry transient token reads while the browser completes OIDC redirects.
- Add bearer-authenticated JSON helpers using httr2.
- Add SALM wrappers for case queries, case retrieval, and phylogenetic trees.
- Add contract coverage and an interactive local end-to-end R script.

## Validation
- `air format --check gen_epix/commondb/services/remote_app.R gen_epix/casedb/services/remote_app.R test/r/test_remote_app.R test/r/test_remote_app_e2e.R`
- `Rscript test/r/test_remote_app.R`
- Live Chromote login against the local mock OIDC provider.
- Live authenticated query, case retrieval, and SLINK tree calculation against CASEDB `SA_SQLITE_DEMO`.

## Notes
- Run `Rscript test/r/test_remote_app_e2e.R` and click the `Dum My` root user to exercise the complete local flow.
