### PR TITLE
fix: restore str() cast before sqlite-prefix check in create_sa_repository

### DIFF
--- a/gen_epix/fastapp/repositories/sa/repository.py
+++ b/gen_epix/fastapp/repositories/sa/repository.py
@@ -1510,9 +1510,9 @@ class SARepository(BaseRepository):
         schema_names = {x.schema_name for x in entities if x.persistable}
 
         # Handle sqlite separately
-        is_sqlite = connection_string is None or connection_string.lower().startswith(
-            "sqlite:///"
-        )
+        is_sqlite = connection_string is None or str(
+            connection_string
+        ).lower().startswith("sqlite:///")
         if is_sqlite:
             sqlite_target = (
                 None


### PR DESCRIPTION
## Summary
- `is_sqlite`'s `connection_string.lower().startswith("sqlite:///")` check assumed `connection_string` is always a `str`, but it can legitimately be a `sqlalchemy.engine.URL` object (e.g. idsdb builds `URL` objects via `URL.create()` instead of raw connection strings, to avoid re-parsing credentials containing URL-structural characters like `@`/`:`/`%`).
- This broke app startup for any consumer passing a `URL` object, with `AttributeError: 'URL' object has no attribute 'lower'`.
- Regression from #648 (`d6848f6c`), which dropped the `str()` cast that was previously wrapping this check.

## Fix
Restore `str(connection_string)` before `.lower()` for this one boolean check. The actual `connection_string` value used to build the engine further down is untouched either way, so this only affects sqlite-vs-not dispatch, not connection behavior.

## Test plan
- [x] Verified locally: a `URL` object → `is_sqlite=False`, `None` → `True`, a sqlite string → `True`.
- [x] Confirmed against a real consumer (idsdb's BN→OMOP ETL, which builds `URL` objects for SQL Server connections) — app composition now proceeds past this point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)